### PR TITLE
Add Each/Skip/Only Variants of Describe and It

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           dotnet-version: 8.0.300
       - name: Build Core
-        run: dotnet build --configuration Release /p:TreatingWarningsAsErrors=true
+        run: dotnet build --configuration Release
         working-directory: ./Detestable
       - name: Build Xunit
-        run: dotnet build --configuration Release  /p:TreatingWarningsAsErrors=true
+        run: dotnet build --configuration Release
         working-directory: ./Detestable.Xunit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           dotnet-version: 8.0.300
       - name: Build Core
-        run: dotnet build --configuration Release
+        run: dotnet build --configuration Release /p:TreatingWarningsAsErrors=true
         working-directory: ./Detestable
       - name: Build Xunit
-        run: dotnet build --configuration Release
+        run: dotnet build --configuration Release  /p:TreatingWarningsAsErrors=true
         working-directory: ./Detestable.Xunit

--- a/Detestable.Tests/FluentUnitTestsExample.cs
+++ b/Detestable.Tests/FluentUnitTestsExample.cs
@@ -2,6 +2,9 @@ namespace Detestable.Tests;
 
 public class FluentUnitTestsExample
 {
+  [Fact]
+  public void MyXunitNormalTest() { }
+
   [Detestable]
   public static void TestScope()
   {

--- a/Detestable.Tests/MultiArgUnitTestsExample.cs
+++ b/Detestable.Tests/MultiArgUnitTestsExample.cs
@@ -25,6 +25,13 @@ public class MultiArgUnitTestsExample
             Assert.True(true);
           }
         );
+        It.Each(
+          ["element", "in", "an", "enumerated", "test"],
+          x => $"Should pass for {x}",
+          (i) => {
+            //
+          }
+        );
       }
     );
 }

--- a/Detestable.Tests/MultiArgUnitTestsExample.cs
+++ b/Detestable.Tests/MultiArgUnitTestsExample.cs
@@ -25,11 +25,29 @@ public class MultiArgUnitTestsExample
             Assert.True(true);
           }
         );
-        It.Each(
-          ["element", "in", "an", "enumerated", "test"],
-          x => $"Should pass for {x}",
+        It.Each<object>(
+          [1, 2, 3, 15, "d", "hello", "world"],
+          "Should pass for {0:x}",
           (i) => {
             //
+          }
+        );
+
+        // Each blocks can be configured to be skipped
+        It.Skip(
+          [1, 2, 3, 15],
+          (i) => $"Should skip for {i:x}",
+          (i) =>
+          {
+            Assert.True(false);
+          }
+        );
+
+        It.Skip(
+          "Should skip this test",
+          () =>
+          {
+            Assert.True(false);
           }
         );
       }

--- a/Detestable.Tests/TestBuilderTests.cs
+++ b/Detestable.Tests/TestBuilderTests.cs
@@ -21,6 +21,14 @@ public class TestBuilderTests
             Assert.Throws<InvalidOperationException>(TestBuilder.ConsumeRootScope);
           }
         );
+        It.Each(
+          [1, 3, 5],
+          "{0} is odd", // Can either use a format string, or a callback like val => $"{val} is odd"
+          (value) =>
+          {
+            (value % 2).Should().Be(1);
+          }
+        );
       }
     );
 

--- a/Detestable.Xunit/DetestableDiscoverer.cs
+++ b/Detestable.Xunit/DetestableDiscoverer.cs
@@ -50,10 +50,18 @@ public sealed class DescribeAttribute(
 {
   /// <summary>
   /// The description of the test suite.
-  /// This is passed to the <see cref="TestBuilder.Describe(string, Action)"/> method.
+  /// This is passed to the <see cref="TestBuilder.Describe(string, Action, int,string)"/> method.
   /// </summary>
   public string Description { get; } = Description;
+
+  /// <summary>
+  /// The file path of the file containing the test suite.
+  /// </summary>
   public string FileName { get; } = FileName;
+
+  /// <summary>
+  /// The line number of the test suite.
+  /// </summary>
   public int LineNumber { get; } = LineNumber;
 }
 

--- a/Detestable.Xunit/DetestableDiscoverer.cs
+++ b/Detestable.Xunit/DetestableDiscoverer.cs
@@ -65,7 +65,7 @@ internal class DescribeDiscoverer : DetestableDiscoverer
 
 internal class DetestableDiscoverer : IXunitTestCaseDiscoverer
 {
-  internal static IEnumerable<IXunitTestCase> TraverseScopesAndYieldTestCases(
+  internal static IEnumerable<DetestableXunitTestCase> TraverseScopesAndYieldTestCases(
     TestScope testScope,
     ITestMethod callingMethod
   )
@@ -98,7 +98,12 @@ internal class DetestableDiscoverer : IXunitTestCaseDiscoverer
   )
   {
     var testScope = GetTestScope(tm, factAttribute);
-    return TraverseScopesAndYieldTestCases(testScope, tm);
+    var cases = TraverseScopesAndYieldTestCases(testScope, tm).ToList();
+    if (cases.Any(x => x.TestBlock.Metadata.IsOnly))
+    {
+      return cases.Where(x => x.TestBlock.Metadata.IsOnly);
+    }
+    return cases;
   }
 }
 

--- a/Detestable.sln
+++ b/Detestable.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Detestable", "Detestable\De
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Detestable.Tests", "Detestable.Tests\Detestable.Tests.csproj", "{6B364EED-8155-4C7E-9EB2-82F9925143F3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Detestable.Xunit", "Detestable.Xunit\Detestable.Xunit.csproj", "{5E7744C1-5102-495E-AF84-E0FB670EAF1C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{6B364EED-8155-4C7E-9EB2-82F9925143F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6B364EED-8155-4C7E-9EB2-82F9925143F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6B364EED-8155-4C7E-9EB2-82F9925143F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E7744C1-5102-495E-AF84-E0FB670EAF1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E7744C1-5102-495E-AF84-E0FB670EAF1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E7744C1-5102-495E-AF84-E0FB670EAF1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E7744C1-5102-495E-AF84-E0FB670EAF1C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Detestable/Describe.Each.cs
+++ b/Detestable/Describe.Each.cs
@@ -1,0 +1,79 @@
+﻿using System.Runtime.CompilerServices;
+using static Detestable.TestBuilder;
+
+namespace Detestable;
+
+public static partial class Describe
+{
+  public static void Each<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    Action<T> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Each(values, descriptionFormatString, lineNumber, filePath).As(body);
+
+  public static void Each<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    Action<T> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Each(values, description, lineNumber, filePath).As(body);
+
+  public static DescribeEachBlock<T> Each<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) =>
+    new(
+      values,
+      v => SafeFormat(descriptionFormatString, v),
+      IsOnly: false,
+      IsSkipped: false,
+      lineNumber,
+      filePath
+    );
+
+  public static DescribeEachBlock<T> Each<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => new(values, description, IsOnly: false, IsSkipped: false, lineNumber, filePath);
+
+  // Invalid Async Methods:
+
+  /// <summary>
+  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
+  /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},int,string)"/> instead.
+  /// </summary>
+  /// <param name="descriptionFormatString"></param>
+  /// <param name="body"></param>
+  /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  public static void Each<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Each(values, descriptionFormatString).As(body);
+
+  /// <summary>
+  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
+  /// Use <see cref="Each{T}(IEnumerable{T},Func{T,string},Action{T},int,string)"/> instead.
+  /// </summary>
+  /// <param name="description"></param>
+  /// <param name="body"></param>
+  /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  public static void Each<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Each(values, description).As(body);
+}

--- a/Detestable/Describe.Each.cs
+++ b/Detestable/Describe.Each.cs
@@ -5,6 +5,15 @@ namespace Detestable;
 
 public static partial class Describe
 {
+  /// <summary>
+  /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -13,14 +22,31 @@ public static partial class Describe
     [CallerFilePath] string filePath = ""
   ) => Each(values, descriptionFormatString, lineNumber, filePath).As(body);
 
+  /// <summary>
+  /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is given.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, description, lineNumber, filePath).As(body);
+  ) => Each(values, descriptionResolver, lineNumber, filePath).As(body);
 
+  /// <summary>
+  /// A fluent api for creating a suite of tests for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeEachBlock<T> Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -36,12 +62,20 @@ public static partial class Describe
       filePath
     );
 
+  /// <summary>
+  /// A fluent api for creating a suite of tests for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeEachBlock<T> Each<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => new(values, description, IsOnly: false, IsSkipped: false, lineNumber, filePath);
+  ) => new(values, descriptionResolver, IsOnly: false, IsSkipped: false, lineNumber, filePath);
 
   // Invalid Async Methods:
 
@@ -49,10 +83,14 @@ public static partial class Describe
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
   /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},int,string)"/> instead.
   /// </summary>
+  /// <typeparam name="T"></typeparam>
+  /// <param name="values"></param>
   /// <param name="descriptionFormatString"></param>
   /// <param name="body"></param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
   public static void Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -65,10 +103,14 @@ public static partial class Describe
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
   /// Use <see cref="Each{T}(IEnumerable{T},Func{T,string},Action{T},int,string)"/> instead.
   /// </summary>
+  /// <typeparam name="T"></typeparam>
+  /// <param name="values"></param>
   /// <param name="description"></param>
   /// <param name="body"></param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
   public static void Each<T>(
     IEnumerable<T> values,
     Func<T, string> description,

--- a/Detestable/Describe.Only.cs
+++ b/Detestable/Describe.Only.cs
@@ -1,0 +1,33 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Detestable;
+
+public static partial class Describe
+{
+  public static void Only(
+    string description,
+    Func<Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(description, lineNumber, filePath).When(body);
+
+  public static void Only(
+    string description,
+    Action body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(description, lineNumber, filePath).When(body);
+
+  public static TestBuilder.ItBlock Only(
+    string description,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) =>
+    new(
+      Description: description,
+      IsOnly: true,
+      IsSkipped: false,
+      LineNumber: lineNumber,
+      FilePath: filePath
+    );
+}

--- a/Detestable/Describe.Only.cs
+++ b/Detestable/Describe.Only.cs
@@ -5,22 +5,47 @@ namespace Detestable;
 
 public static partial class Describe
 {
+  /// <summary>
+  /// Creates a suite of tests that will be run exclusively.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the descriptions's body</typeparam>
+  /// <param name="values">A list of values to pass to the description</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="body">The method body of the description. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
-    string description,
+    string descriptionFormatString,
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, description, lineNumber, filePath).As(body);
+  ) => Only(values, descriptionFormatString, lineNumber, filePath).As(body);
 
+  /// <summary>
+  /// Creates a suite of tests that will be run exclusively.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the descriptions's body</typeparam>
+  /// <param name="values">A list of values to pass to the description</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="body">The method body of the description. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, description, lineNumber, filePath).As(body);
+  ) => Only(values, descriptionResolver, lineNumber, filePath).As(body);
 
+  /// <summary>
+  /// Creates a suite of tests that will be run exclusively.
+  /// </summary>
+  /// <param name="description">The description of the describe block</param>
+  /// <param name="body">The method body of the description</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only(
     string description,
     Action body,
@@ -28,6 +53,12 @@ public static partial class Describe
     [CallerFilePath] string filePath = ""
   ) => Only(description, lineNumber, filePath).As(body);
 
+  /// <summary>
+  /// A fluent api for creating a describe block that will be run exclusively.
+  /// </summary>
+  /// <param name="description">The description of the describe block</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeBlock Only(
     string description,
     [CallerLineNumber] int lineNumber = 0,
@@ -41,6 +72,15 @@ public static partial class Describe
       FilePath: filePath
     );
 
+  /// <summary>
+  /// A fluent api for creating a suite of tests that will be run exclusively.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the descriptions's body</typeparam>
+  /// <param name="values">A list of values to pass to the description</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <returns></returns>
   public static DescribeEachBlock<T> Only<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -48,12 +88,21 @@ public static partial class Describe
     [CallerFilePath] string filePath = ""
   ) => Only(values, x => SafeFormat(descriptionFormatString, x), lineNumber, filePath);
 
+  /// <summary>
+  /// A fluent api for creating a suite of tests that will be run exclusively.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the descriptions's body</typeparam>
+  /// <param name="values">A list of values to pass to the description</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <returns></returns>
   public static DescribeEachBlock<T> Only<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => new(values, description, IsOnly: true, IsSkipped: false, lineNumber, filePath);
+  ) => new(values, descriptionResolver, IsOnly: true, IsSkipped: false, lineNumber, filePath);
 
   // Invalid Async Methods:
 
@@ -63,8 +112,10 @@ public static partial class Describe
   /// </summary>
   /// <param name="description"></param>
   /// <param name="body"></param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
   public static void Only(
     string description,
     Func<Task> body,
@@ -76,10 +127,13 @@ public static partial class Describe
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
   /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},int,string)"/> instead.
   /// </summary>
+  /// <param name="values"></param>
   /// <param name="descriptionFormatString"></param>
   /// <param name="body"></param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
   public static void Only<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -89,18 +143,21 @@ public static partial class Describe
   ) => Only(values, descriptionFormatString).As(body);
 
   /// <summary>
-  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeOnly(Func{Task})" />.
+  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
   /// Use <see cref="Only{T}(IEnumerable{T},Func{T,string},Action{T},int,string)"/> instead.
   /// </summary>
-  /// <param name="description"></param>
+  /// <param name="values"></param>
+  /// <param name="descriptionResolver"></param>
   /// <param name="body"></param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
   public static void Only<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     Func<T, Task> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, description).As(body);
+  ) => Only(values, descriptionResolver).As(body);
 }

--- a/Detestable/Describe.Only.cs
+++ b/Detestable/Describe.Only.cs
@@ -1,24 +1,34 @@
 ﻿using System.Runtime.CompilerServices;
+using static Detestable.TestBuilder;
 
 namespace Detestable;
 
 public static partial class Describe
 {
-  public static void Only(
+  public static void Only<T>(
+    IEnumerable<T> values,
     string description,
-    Func<Task> body,
+    Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(description, lineNumber, filePath).When(body);
+  ) => Only(values, description, lineNumber, filePath).As(body);
+
+  public static void Only<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    Action<T> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(values, description, lineNumber, filePath).As(body);
 
   public static void Only(
     string description,
     Action body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(description, lineNumber, filePath).When(body);
+  ) => Only(description, lineNumber, filePath).As(body);
 
-  public static TestBuilder.ItBlock Only(
+  public static DescribeBlock Only(
     string description,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
@@ -30,4 +40,67 @@ public static partial class Describe
       LineNumber: lineNumber,
       FilePath: filePath
     );
+
+  public static DescribeEachBlock<T> Only<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(values, x => SafeFormat(descriptionFormatString, x), lineNumber, filePath);
+
+  public static DescribeEachBlock<T> Only<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => new(values, description, IsOnly: true, IsSkipped: false, lineNumber, filePath);
+
+  // Invalid Async Methods:
+
+  /// <summary>
+  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
+  /// Use <see cref="Only(string,Action,int,string)"/> instead.
+  /// </summary>
+  /// <param name="description"></param>
+  /// <param name="body"></param>
+  /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  public static void Only(
+    string description,
+    Func<Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(description).As(body);
+
+  /// <summary>
+  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
+  /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},int,string)"/> instead.
+  /// </summary>
+  /// <param name="descriptionFormatString"></param>
+  /// <param name="body"></param>
+  /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  public static void Only<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(values, descriptionFormatString).As(body);
+
+  /// <summary>
+  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeOnly(Func{Task})" />.
+  /// Use <see cref="Only{T}(IEnumerable{T},Func{T,string},Action{T},int,string)"/> instead.
+  /// </summary>
+  /// <param name="description"></param>
+  /// <param name="body"></param>
+  /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  public static void Only<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(values, description).As(body);
 }

--- a/Detestable/Describe.Skip.cs
+++ b/Detestable/Describe.Skip.cs
@@ -3,23 +3,52 @@ using static Detestable.TestBuilder;
 
 namespace Detestable;
 
+/// <summary>
+/// Provides methods for creating variations of describe blocks, such as Only, Each, and Skip.
+/// </summary>
 public static partial class Describe
 {
+  /// <summary>
+  /// Creates a suite of tests that will be skipped.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the descriptions's body</typeparam>
+  /// <param name="values">A list of values to pass to the description</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="body">The method body of the description. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
-    string description,
+    string descriptionFormatString,
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, description, lineNumber, filePath).As(body);
+  ) => Skip(values, descriptionFormatString, lineNumber, filePath).As(body);
 
+  /// <summary>
+  /// Creates a suite of tests that will be skipped.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the descriptions's body</typeparam>
+  /// <param name="values">A list of values to pass to the description</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="body">The method body of the description. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, description, lineNumber, filePath).As(body);
+  ) => Skip(values, descriptionResolver, lineNumber, filePath).As(body);
+
+  /// <summary>
+  /// Creates a suite of tests that will be skipped.
+  /// </summary>
+  /// <param name="description">The description of the describe block</param>
+  /// <param name="body">The method body of the description</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
 
   public static void Skip(
     string description,
@@ -28,6 +57,13 @@ public static partial class Describe
     [CallerFilePath] string filePath = ""
   ) => Skip(description, lineNumber, filePath).As(body);
 
+  /// <summary>
+  /// A fluent api for creating a suite of tests that will be skipped.
+  /// See <see cref="DescribeBlock.As(Action)"/>.
+  /// </summary>
+  /// <param name="description">The description of the describe block</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeBlock Skip(
     string description,
     [CallerLineNumber] int lineNumber = 0,
@@ -41,6 +77,15 @@ public static partial class Describe
       FilePath: filePath
     );
 
+  /// <summary>
+  /// A fluent api for creating a suite of tests that will be skipped.
+  /// See <see cref="DescribeEachBlock{T}.As(Action{T})"/>.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test description</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeEachBlock<T> Skip<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -48,12 +93,21 @@ public static partial class Describe
     [CallerFilePath] string filePath = ""
   ) => Skip(values, x => SafeFormat(descriptionFormatString, x), lineNumber, filePath);
 
+  /// <summary>
+  /// A fluent api for creating a suite of tests that will be skipped.
+  /// See <see cref="DescribeEachBlock{T}.As(Action{T})"/>.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test description</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeEachBlock<T> Skip<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => new(values, description, IsOnly: false, IsSkipped: true, lineNumber, filePath);
+  ) => new(values, descriptionResolver, IsOnly: false, IsSkipped: true, lineNumber, filePath);
 
   // Invalid Async Methods:
 
@@ -63,8 +117,10 @@ public static partial class Describe
   /// </summary>
   /// <param name="description"></param>
   /// <param name="body"></param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
   public static void Skip(
     string description,
     Func<Task> body,
@@ -76,10 +132,14 @@ public static partial class Describe
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
   /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},int,string)"/> instead.
   /// </summary>
+  /// <typeparam name="T"></typeparam>
+  /// <param name="values"></param>
   /// <param name="descriptionFormatString"></param>
   /// <param name="body"></param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
   public static void Skip<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -89,13 +149,17 @@ public static partial class Describe
   ) => Skip(values, descriptionFormatString).As(body);
 
   /// <summary>
-  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeSkip(Func{Task})" />.
+  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
   /// Use <see cref="Skip{T}(IEnumerable{T},Func{T,string},Action{T},int,string)"/> instead.
   /// </summary>
+  /// <typeparam name="T"></typeparam>
+  /// <param name="values"></param>
   /// <param name="description"></param>
   /// <param name="body"></param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
   public static void Skip<T>(
     IEnumerable<T> values,
     Func<T, string> description,

--- a/Detestable/Describe.Skip.cs
+++ b/Detestable/Describe.Skip.cs
@@ -1,0 +1,106 @@
+﻿using System.Runtime.CompilerServices;
+using static Detestable.TestBuilder;
+
+namespace Detestable;
+
+public static partial class Describe
+{
+  public static void Skip<T>(
+    IEnumerable<T> values,
+    string description,
+    Action<T> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Skip(values, description, lineNumber, filePath).As(body);
+
+  public static void Skip<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    Action<T> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Skip(values, description, lineNumber, filePath).As(body);
+
+  public static void Skip(
+    string description,
+    Action body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Skip(description, lineNumber, filePath).As(body);
+
+  public static DescribeBlock Skip(
+    string description,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) =>
+    new(
+      Description: description,
+      IsOnly: false,
+      IsSkipped: true,
+      LineNumber: lineNumber,
+      FilePath: filePath
+    );
+
+  public static DescribeEachBlock<T> Skip<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Skip(values, x => SafeFormat(descriptionFormatString, x), lineNumber, filePath);
+
+  public static DescribeEachBlock<T> Skip<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => new(values, description, IsOnly: false, IsSkipped: true, lineNumber, filePath);
+
+  // Invalid Async Methods:
+
+  /// <summary>
+  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
+  /// Use <see cref="Skip(string,Action,int,string)"/> instead.
+  /// </summary>
+  /// <param name="description"></param>
+  /// <param name="body"></param>
+  /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  public static void Skip(
+    string description,
+    Func<Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Skip(description).As(body);
+
+  /// <summary>
+  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
+  /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},int,string)"/> instead.
+  /// </summary>
+  /// <param name="descriptionFormatString"></param>
+  /// <param name="body"></param>
+  /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  public static void Skip<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Skip(values, descriptionFormatString).As(body);
+
+  /// <summary>
+  /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeSkip(Func{Task})" />.
+  /// Use <see cref="Skip{T}(IEnumerable{T},Func{T,string},Action{T},int,string)"/> instead.
+  /// </summary>
+  /// <param name="description"></param>
+  /// <param name="body"></param>
+  /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  public static void Skip<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Skip(values, description).As(body);
+}

--- a/Detestable/Detestable.csproj
+++ b/Detestable/Detestable.csproj
@@ -10,4 +10,10 @@
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
     <InternalsVisibleTo Include="$(AssemblyName).Xunit" />
   </ItemGroup>
+
+
+  <ItemGroup>
+    <Using Include="Detestable.Internal.Util"  Static="True"  />
+  </ItemGroup>
+
 </Project>

--- a/Detestable/Internal/DetestableTestExecutionMethodRunner.cs
+++ b/Detestable/Internal/DetestableTestExecutionMethodRunner.cs
@@ -13,6 +13,12 @@ internal class DetestableTestBlockRunner(
   public async Task<DetestableRunSummary> RunAsync()
   {
     var result = new DetestableRunSummary(Total: 1);
+    if (testBlock.Metadata.IsSkipped || testScope.AnyParentsOrThis(s => s.Metadata.IsSkipped))
+    {
+      messageBus.OnTestSkipped(testBlock, testScope, "");
+      return result with { Skipped = 1 };
+    }
+
     var sw = Stopwatch.StartNew();
 
     messageBus.OnBeforeTestSetupStarting(testBlock, testScope);
@@ -100,9 +106,9 @@ internal class DetestableTestBlockRunner(
     {
       await RunBeforeEachesIncludingParentsAsync(testScope.Parent);
     }
-    foreach (var beforeAll in testScope.TestBeforeEachs)
+    foreach (var beforeEach in testScope.TestBeforeEachs)
     {
-      await beforeAll.Body.Invoke();
+      await beforeEach.Body.Invoke();
     }
   }
 }

--- a/Detestable/Internal/TestDescription.cs
+++ b/Detestable/Internal/TestDescription.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace Detestable;
 
-internal record TestScope(string Description, TestScope? Parent)
+internal record TestScope(string Description, TestScope? Parent, TestMetadata Metadata)
 {
   internal bool HasRunBeforeAlls { get; set; }
   internal bool HasRunAfterAlls { get; set; }
@@ -12,6 +12,20 @@ internal record TestScope(string Description, TestScope? Parent)
   internal List<TestSetupMethod> TestAfterAlls { get; } = [];
   internal List<TestBlock> TestMethods { get; } = [];
   internal List<TestScope> Children { get; } = [];
+
+  internal bool AnyParentsOrThis(Func<TestScope, bool> predicate)
+  {
+    var current = this;
+    while (current != null)
+    {
+      if (predicate(current))
+      {
+        return true;
+      }
+      current = current.Parent;
+    }
+    return false;
+  }
 
   internal IEnumerable<(TestBlock TestBlock, TestScope TestScope)> EnumerateTests()
   {
@@ -39,7 +53,8 @@ internal record TestMetadata(
   int ScopeIndex,
   int LineNumber,
   string FilePath,
-  bool IsOnly
+  bool IsOnly,
+  bool IsSkipped
 );
 
 internal record TestBlock(Func<Task> Body, TestMetadata Metadata)

--- a/Detestable/Internal/TestDescription.cs
+++ b/Detestable/Internal/TestDescription.cs
@@ -27,6 +27,24 @@ internal record TestScope(TestScope? Parent, TestMetadata Metadata)
     return false;
   }
 
+  internal bool AnyChildrenOrThis(Func<TestScope, bool> predicate)
+  {
+    if (predicate(this))
+    {
+      return true;
+    }
+
+    foreach (var child in Children)
+    {
+      if (child.AnyChildrenOrThis(predicate))
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   internal IEnumerable<(TestBlock TestBlock, TestScope TestScope)> EnumerateTests()
   {
     foreach (var test in TestMethods)
@@ -42,6 +60,9 @@ internal record TestScope(TestScope? Parent, TestMetadata Metadata)
       }
     }
   }
+
+  internal bool AnyScopesOrTestsAreOnly =>
+    AnyChildrenOrThis(sc => sc.Metadata.IsOnly || sc.TestMethods.Any(tm => tm.Metadata.IsOnly));
 }
 
 internal record TestSetupMethod(Func<Task> Body);

--- a/Detestable/Internal/TestDescription.cs
+++ b/Detestable/Internal/TestDescription.cs
@@ -2,7 +2,7 @@ using System.Text;
 
 namespace Detestable;
 
-internal record TestScope(string Description, TestScope? Parent, TestMetadata Metadata)
+internal record TestScope(TestScope? Parent, TestMetadata Metadata)
 {
   internal bool HasRunBeforeAlls { get; set; }
   internal bool HasRunAfterAlls { get; set; }
@@ -65,10 +65,10 @@ internal record TestBlock(Func<Task> Body, TestMetadata Metadata)
     var parent = scope.Parent;
     while (parent != null)
     {
-      sb.Insert(0, parent.Description + " ");
+      sb.Insert(0, parent.Metadata.Description + " ");
       parent = parent.Parent;
     }
-    sb.Append(scope.Description).Append(' ').Append(Metadata.Description);
+    sb.Append(scope.Metadata.Description).Append(' ').Append(Metadata.Description);
     return sb.ToString();
   }
 }

--- a/Detestable/Internal/TestDescription.cs
+++ b/Detestable/Internal/TestDescription.cs
@@ -34,7 +34,13 @@ internal record TestSetupMethod(Func<Task> Body);
 
 internal record TestAfterEachMethod(Func<FinishedTestContext, Task> Body);
 
-internal record TestMetadata(string Description, int ScopeIndex, int LineNumber, string FilePath);
+internal record TestMetadata(
+  string Description,
+  int ScopeIndex,
+  int LineNumber,
+  string FilePath,
+  bool IsOnly
+);
 
 internal record TestBlock(Func<Task> Body, TestMetadata Metadata)
 {

--- a/Detestable/Internal/Util.cs
+++ b/Detestable/Internal/Util.cs
@@ -1,0 +1,16 @@
+namespace Detestable.Internal;
+
+internal static class Util
+{
+  internal static string SafeFormat<T>(string format, T item)
+  {
+    try
+    {
+      return string.Format(format, item);
+    }
+    catch (FormatException)
+    {
+      return format;
+    }
+  }
+}

--- a/Detestable/It.Each.cs
+++ b/Detestable/It.Each.cs
@@ -1,0 +1,70 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Detestable;
+
+public static partial class It
+{
+  public static void Each<T>(
+    IEnumerable<T> values,
+    string description,
+    Action<T> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  )
+  {
+    foreach (var value in values)
+    {
+      // Make sure to copy the value to avoid closure issues
+      var val = value;
+      TestBuilder.It(description + " " + value, lineNumber, filePath).When(() => body(val));
+    }
+  }
+
+  public static void Each<T>(
+    IEnumerable<T> values,
+    string description,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  )
+  {
+    foreach (var value in values)
+    {
+      // Make sure to copy the value to avoid closure issues
+      var val = value;
+      TestBuilder.It(description + " " + value, lineNumber, filePath).When(() => body(val));
+    }
+  }
+
+  public static void Each<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    Action<T> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  )
+  {
+    foreach (var value in values)
+    {
+      // Make sure to copy the value to avoid closure issues
+      var val = value;
+      TestBuilder.It(description(value), lineNumber, filePath).When(() => body(val));
+    }
+  }
+
+  public static void Each<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  )
+  {
+    foreach (var value in values)
+    {
+      // Make sure to copy the value to avoid closure issues
+      var val = value;
+      TestBuilder.It(description(value), lineNumber, filePath).When(() => body(val));
+    }
+  }
+}

--- a/Detestable/It.Each.cs
+++ b/Detestable/It.Each.cs
@@ -5,6 +5,15 @@ namespace Detestable;
 
 public static partial class It
 {
+  /// <summary>
+  /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -13,6 +22,15 @@ public static partial class It
     [CallerFilePath] string filePath = ""
   ) => Each(values, descriptionFormatString, lineNumber, filePath).When(body);
 
+  /// <summary>
+  /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -21,22 +39,49 @@ public static partial class It
     [CallerFilePath] string filePath = ""
   ) => Each(values, descriptionFormatString, lineNumber, filePath).When(body);
 
+  /// <summary>
+  /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, description, lineNumber, filePath).When(body);
+  ) => Each(values, descriptionResolver, lineNumber, filePath).When(body);
 
+  /// <summary>
+  /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     Func<T, Task> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, description, lineNumber, filePath).When(body);
+  ) => Each(values, descriptionResolver, lineNumber, filePath).When(body);
 
+  /// <summary>
+  /// A fluent api for creating a suite of tests for every element in the <paramref name="values"/> collection.
+  /// See <see cref="ItEachBlock{T}.When(Action{T})"/>.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItEachBlock<T> Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -52,10 +97,20 @@ public static partial class It
       filePath
     );
 
+  /// <summary>
+  /// A fluent api for creating a suite of tests for every element in the <paramref name="values"/> collection.
+  /// See <see cref="ItEachBlock{T}.When(Action{T})"/>.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
+
   public static ItEachBlock<T> Each<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => new(values, description, IsOnly: false, IsSkipped: false, lineNumber, filePath);
+  ) => new(values, descriptionResolver, IsOnly: false, IsSkipped: false, lineNumber, filePath);
 }

--- a/Detestable/It.Each.cs
+++ b/Detestable/It.Each.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using static Detestable.TestBuilder;
 
 namespace Detestable;
 
@@ -6,35 +7,19 @@ public static partial class It
 {
   public static void Each<T>(
     IEnumerable<T> values,
-    string description,
+    string descriptionFormatString,
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  )
-  {
-    foreach (var value in values)
-    {
-      // Make sure to copy the value to avoid closure issues
-      var val = value;
-      TestBuilder.It(description + " " + value, lineNumber, filePath).When(() => body(val));
-    }
-  }
+  ) => Each(values, descriptionFormatString, lineNumber, filePath).When(body);
 
   public static void Each<T>(
     IEnumerable<T> values,
-    string description,
+    string descriptionFormatString,
     Func<T, Task> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  )
-  {
-    foreach (var value in values)
-    {
-      // Make sure to copy the value to avoid closure issues
-      var val = value;
-      TestBuilder.It(description + " " + value, lineNumber, filePath).When(() => body(val));
-    }
-  }
+  ) => Each(values, descriptionFormatString, lineNumber, filePath).When(body);
 
   public static void Each<T>(
     IEnumerable<T> values,
@@ -42,15 +27,7 @@ public static partial class It
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  )
-  {
-    foreach (var value in values)
-    {
-      // Make sure to copy the value to avoid closure issues
-      var val = value;
-      TestBuilder.It(description(value), lineNumber, filePath).When(() => body(val));
-    }
-  }
+  ) => Each(values, description, lineNumber, filePath).When(body);
 
   public static void Each<T>(
     IEnumerable<T> values,
@@ -58,13 +35,27 @@ public static partial class It
     Func<T, Task> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  )
-  {
-    foreach (var value in values)
-    {
-      // Make sure to copy the value to avoid closure issues
-      var val = value;
-      TestBuilder.It(description(value), lineNumber, filePath).When(() => body(val));
-    }
-  }
+  ) => Each(values, description, lineNumber, filePath).When(body);
+
+  public static ItEachBlock<T> Each<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) =>
+    new(
+      values,
+      v => SafeFormat(descriptionFormatString, v),
+      IsOnly: false,
+      IsSkipped: false,
+      lineNumber,
+      filePath
+    );
+
+  public static ItEachBlock<T> Each<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => new(values, description, IsOnly: false, IsSkipped: false, lineNumber, filePath);
 }

--- a/Detestable/It.Only.cs
+++ b/Detestable/It.Only.cs
@@ -1,0 +1,26 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Detestable;
+
+public static partial class It
+{
+  public static void Only(
+    string description,
+    Func<Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(description, lineNumber, filePath).When(body);
+
+  public static void Only(
+    string description,
+    Action body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(description, lineNumber, filePath).When(body);
+
+  public static TestBuilder.ItBlock Only(
+    string description,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => new(description, lineNumber, filePath, true);
+}

--- a/Detestable/It.Only.cs
+++ b/Detestable/It.Only.cs
@@ -1,9 +1,17 @@
 ﻿using System.Runtime.CompilerServices;
+using static Detestable.TestBuilder;
 
 namespace Detestable;
 
 public static partial class It
 {
+  /// <summary>
+  /// Creates a test that will be the only test being run.
+  /// </summary>
+  /// <param name="description">The description of the test</param>
+  /// <param name="body">The test body. Assertions should go in here</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only(
     string description,
     Func<Task> body,
@@ -11,6 +19,13 @@ public static partial class It
     [CallerFilePath] string filePath = ""
   ) => Only(description, lineNumber, filePath).When(body);
 
+  /// <summary>
+  /// Creates a test that will be the only test being run.
+  /// </summary>
+  /// <param name="description">The description of the test</param>
+  /// <param name="body">The test body. Assertions should go in here</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only(
     string description,
     Action body,
@@ -18,7 +33,14 @@ public static partial class It
     [CallerFilePath] string filePath = ""
   ) => Only(description, lineNumber, filePath).When(body);
 
-  public static TestBuilder.ItBlock Only(
+  /// <summary>
+  /// A fluent api for creating a test that will be the only test being run.
+  /// See <see cref="ItBlock.When(Func{Task})"/>.
+  /// </summary>
+  /// <param name="description">The description of the test</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
+  public static ItBlock Only(
     string description,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
@@ -30,4 +52,112 @@ public static partial class It
       LineNumber: lineNumber,
       FilePath: filePath
     );
+
+  /// <summary>
+  /// Creates a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
+  public static void Only<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    Action<T> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(values, descriptionFormatString, lineNumber, filePath).When(body);
+
+  /// <summary>
+  /// Creates a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
+  public static void Only<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(values, descriptionFormatString, lineNumber, filePath).When(body);
+
+  /// <summary>
+  /// Creates a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
+  public static void Only<T>(
+    IEnumerable<T> values,
+    Func<T, string> descriptionResolver,
+    Action<T> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(values, descriptionResolver, lineNumber, filePath).When(body);
+
+  /// <summary>
+  /// Creates a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
+  public static void Only<T>(
+    IEnumerable<T> values,
+    Func<T, string> descriptionResolver,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Only(values, descriptionResolver, lineNumber, filePath).When(body);
+
+  /// <summary>
+  /// A fluent api for creating a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
+  /// See <see cref="ItEachBlock{T}.When(Action{T})"/>.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
+  public static ItEachBlock<T> Only<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) =>
+    new(
+      values,
+      v => SafeFormat(descriptionFormatString, v),
+      IsOnly: true,
+      IsSkipped: false,
+      lineNumber,
+      filePath
+    );
+
+  /// <summary>
+  /// A fluent api for creating a suite of tests for every element in the <paramref name="values"/> collection.
+  /// See <see cref="ItEachBlock{T}.When(Action{T})"/>.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
+  public static ItEachBlock<T> Only<T>(
+    IEnumerable<T> values,
+    Func<T, string> descriptionResolver,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => new(values, descriptionResolver, IsOnly: true, IsSkipped: false, lineNumber, filePath);
 }

--- a/Detestable/It.Only.cs
+++ b/Detestable/It.Only.cs
@@ -22,5 +22,12 @@ public static partial class It
     string description,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => new(description, lineNumber, filePath, true);
+  ) =>
+    new(
+      Description: description,
+      IsOnly: true,
+      IsSkipped: false,
+      LineNumber: lineNumber,
+      FilePath: filePath
+    );
 }

--- a/Detestable/It.Skip.cs
+++ b/Detestable/It.Skip.cs
@@ -1,0 +1,53 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Detestable;
+
+public static partial class It
+{
+  /// <returns></returns>
+  public static void Skip<T>(
+    IEnumerable<T> values,
+    string description,
+    Action<T> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) { }
+
+  public static void Skip<T>(
+    IEnumerable<T> values,
+    string description,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) { }
+
+  public static void Skip<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    Action<T> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) { }
+
+  public static void Skip<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    Func<T, Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) { }
+
+  public static void Skip(
+    string description,
+    Func<Task> body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) { }
+
+  public static void Skip(
+    string description,
+    Action body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) { }
+}

--- a/Detestable/It.Skip.cs
+++ b/Detestable/It.Skip.cs
@@ -3,39 +3,87 @@ using static Detestable.TestBuilder;
 
 namespace Detestable;
 
+/// <summary>
+/// Provides methods for creating variations of Tests, such as Only, Each, and Skip.
+/// </summary>
 public static partial class It
 {
+  /// <summary>
+  /// Creates a suite of tests that will be skipped for every element in the <paramref name="values"/> collection..
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
-    string description,
+    string descriptionFormatString,
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, description, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionFormatString, lineNumber, filePath).When(body);
 
+  /// <summary>
+  /// Creates a suite of tests that will be skipped for every element in the <paramref name="values"/> collection..
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
-    string description,
+    string descriptionFormatString,
     Func<T, Task> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, description, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionFormatString, lineNumber, filePath).When(body);
 
+  /// <summary>
+  /// Creates a suite of tests that will be skipped for every element in the <paramref name="values"/> collection..
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, description, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionResolver, lineNumber, filePath).When(body);
+
+  /// <summary>
+  /// Creates a suite of tests that will be skipped for every element in the <paramref name="values"/> collection..
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
 
   public static void Skip<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     Func<T, Task> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, description, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionResolver, lineNumber, filePath).When(body);
+
+  /// <summary>
+  /// Creates a test that will be skipped.
+  /// </summary>
+  /// <param name="description">The description of the test</param>
+  /// <param name="body">The method body of the test where assertions should be put</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
 
   public static void Skip(
     string description,
@@ -44,6 +92,13 @@ public static partial class It
     [CallerFilePath] string filePath = ""
   ) => Skip(description, lineNumber, filePath).When(body);
 
+  /// <summary>
+  /// Creates a test that will be skipped.
+  /// </summary>
+  /// <param name="description">The description of the test</param>
+  /// <param name="body">The method body of the test where assertions should be put</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip(
     string description,
     Action body,
@@ -51,6 +106,12 @@ public static partial class It
     [CallerFilePath] string filePath = ""
   ) => Skip(description, lineNumber, filePath).When(body);
 
+  /// <summary>
+  /// A fluent api for creating a test that will be skipped. See <see cref="ItBlock.When(Action)"/>.
+  /// </summary>
+  /// <param name="description">The description of the test</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItBlock Skip(
     string description,
     [CallerLineNumber] int lineNumber = 0,
@@ -64,6 +125,14 @@ public static partial class It
       FilePath: filePath
     );
 
+  /// <summary>
+  /// A fluent api for creating a suite of tests that will be skipped. See <see cref="ItEachBlock{T}.When(Action{T})"/>.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItEachBlock<T> Skip<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -71,10 +140,18 @@ public static partial class It
     [CallerFilePath] string filePath = ""
   ) => Skip(values, x => SafeFormat(descriptionFormatString, x), lineNumber, filePath);
 
+  /// <summary>
+  /// A fluent api for creating a suite of tests that will be skipped. See <see cref="ItEachBlock{T}.When(Action{T})"/>.
+  /// </summary>
+  /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
+  /// <param name="values">A list of values to pass to the test</param>
+  /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItEachBlock<T> Skip<T>(
     IEnumerable<T> values,
-    Func<T, string> description,
+    Func<T, string> descriptionResolver,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => new(values, description, IsOnly: false, IsSkipped: true, lineNumber, filePath);
+  ) => new(values, descriptionResolver, IsOnly: false, IsSkipped: true, lineNumber, filePath);
 }

--- a/Detestable/It.Skip.cs
+++ b/Detestable/It.Skip.cs
@@ -1,17 +1,17 @@
 ﻿using System.Runtime.CompilerServices;
+using static Detestable.TestBuilder;
 
 namespace Detestable;
 
 public static partial class It
 {
-  /// <returns></returns>
   public static void Skip<T>(
     IEnumerable<T> values,
     string description,
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) { }
+  ) => Skip(values, description, lineNumber, filePath).When(body);
 
   public static void Skip<T>(
     IEnumerable<T> values,
@@ -19,7 +19,7 @@ public static partial class It
     Func<T, Task> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) { }
+  ) => Skip(values, description, lineNumber, filePath).When(body);
 
   public static void Skip<T>(
     IEnumerable<T> values,
@@ -27,7 +27,7 @@ public static partial class It
     Action<T> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) { }
+  ) => Skip(values, description, lineNumber, filePath).When(body);
 
   public static void Skip<T>(
     IEnumerable<T> values,
@@ -35,19 +35,46 @@ public static partial class It
     Func<T, Task> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) { }
+  ) => Skip(values, description, lineNumber, filePath).When(body);
 
   public static void Skip(
     string description,
     Func<Task> body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) { }
+  ) => Skip(description, lineNumber, filePath).When(body);
 
   public static void Skip(
     string description,
     Action body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) { }
+  ) => Skip(description, lineNumber, filePath).When(body);
+
+  public static ItBlock Skip(
+    string description,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) =>
+    new(
+      Description: description,
+      IsOnly: false,
+      IsSkipped: true,
+      LineNumber: lineNumber,
+      FilePath: filePath
+    );
+
+  public static ItEachBlock<T> Skip<T>(
+    IEnumerable<T> values,
+    string descriptionFormatString,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => Skip(values, x => SafeFormat(descriptionFormatString, x), lineNumber, filePath);
+
+  public static ItEachBlock<T> Skip<T>(
+    IEnumerable<T> values,
+    Func<T, string> description,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  ) => new(values, description, IsOnly: false, IsSkipped: true, lineNumber, filePath);
 }

--- a/Detestable/TestBuilder.AfterAll.cs
+++ b/Detestable/TestBuilder.AfterAll.cs
@@ -1,9 +1,5 @@
 ﻿namespace Detestable;
 
-/// <summary>
-/// Provides methods for building test suites using a declarative syntax.
-/// Generally should be used with the <c>using static Detestable.TestBuilder</c> directive.
-/// </summary>
 public static partial class TestBuilder
 {
   /// <summary>

--- a/Detestable/TestBuilder.AfterEach.cs
+++ b/Detestable/TestBuilder.AfterEach.cs
@@ -1,9 +1,5 @@
 ﻿namespace Detestable;
 
-/// <summary>
-/// Provides methods for building test suites using a declarative syntax.
-/// Generally should be used with the <c>using static Detestable.TestBuilder</c> directive.
-/// </summary>
 public static partial class TestBuilder
 {
   /// <summary>

--- a/Detestable/TestBuilder.BeforeAll.cs
+++ b/Detestable/TestBuilder.BeforeAll.cs
@@ -1,9 +1,5 @@
 ﻿namespace Detestable;
 
-/// <summary>
-/// Provides methods for building test suites using a declarative syntax.
-/// Generally should be used with the <c>using static Detestable.TestBuilder</c> directive.
-/// </summary>
 public static partial class TestBuilder
 {
   /// <summary>

--- a/Detestable/TestBuilder.BeforeEach.cs
+++ b/Detestable/TestBuilder.BeforeEach.cs
@@ -1,9 +1,5 @@
 ﻿namespace Detestable;
 
-/// <summary>
-/// Provides methods for building test suites using a declarative syntax.
-/// Generally should be used with the <c>using static Detestable.TestBuilder</c> directive.
-/// </summary>
 public static partial class TestBuilder
 {
   /// <summary>

--- a/Detestable/TestBuilder.Describe.cs
+++ b/Detestable/TestBuilder.Describe.cs
@@ -8,6 +8,12 @@ namespace Detestable;
 /// </summary>
 public static partial class TestBuilder
 {
+  internal const string InvalidDescribeAsyncMethodCallMessage = """
+    Must call Describe methods with a synchronous body.
+    Use BeforeAll, BeforeEach to perform asynchronous test setup.
+    Remove async from the method signature to fix this error.
+    """;
+
   /// <summary>
   /// Obsolete. Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
   /// Use <see cref="Describe(string,Action,int,string)"/> instead.
@@ -15,15 +21,9 @@ public static partial class TestBuilder
   /// <param name="description"></param>
   /// <param name="body"></param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(
-    "Do not call Describe with an async body. Use BeforeAll, BeforeEach to perform asynchronous test setup. Remove async from the method signature to fix this error."
-  )]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
   public static void Describe(string description, Func<Task> body) =>
-    throw new InvalidOperationException(
-      @"Must call Describe methods with a synchronous body.
-             Use BeforeAll, BeforeEach to perform asynchronous test setup.
-             Remove async from the method signature to fix this error."
-    );
+    throw new InvalidOperationException(InvalidDescribeAsyncMethodCallMessage);
 
   /// <summary>
   /// Describes a suite of tests.
@@ -36,33 +36,7 @@ public static partial class TestBuilder
     Action body,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  )
-  {
-    var scopeIndex = CurrentScope?.Children.Count ?? 0;
-    var metadata = new TestMetadata(
-      description,
-      scopeIndex,
-      lineNumber,
-      filePath,
-      IsOnly: false,
-      IsSkipped: false
-    );
-    if (RootScope == null)
-    {
-      CurrentScope = new TestScope(description, null, metadata);
-      RootScope = CurrentScope;
-    }
-    else
-    {
-      var parent = CurrentScope;
-      CurrentScope = new TestScope(description, parent, metadata);
-      parent?.Children.Add(CurrentScope);
-    }
-
-    body();
-    // Pop back to the parent scope after running all the inner scopes
-    CurrentScope = CurrentScope.Parent;
-  }
+  ) => Describe(description, lineNumber, filePath).As(body);
 
   /// <summary>
   /// Describes a suite of tests using a fluent syntax.  Specify the body of the suite using the <see cref="DescribeBlock.As" /> method.
@@ -75,35 +49,20 @@ public static partial class TestBuilder
     [CallerFilePath] string filePath = ""
   )
   {
-    var scopeIndex = CurrentScope?.Children.Count ?? 0;
-    var metadata = new TestMetadata(
-      description,
-      scopeIndex,
-      lineNumber,
-      filePath,
-      IsOnly: false,
-      IsSkipped: false
-    );
-    if (RootScope == null)
-    {
-      CurrentScope = new TestScope(description, null, metadata);
-      RootScope = CurrentScope;
-    }
-    else
-    {
-      var parent = CurrentScope;
-      CurrentScope = new TestScope(description, parent, metadata);
-      parent?.Children.Add(CurrentScope);
-    }
-
-    return new DescribeBlock(description);
+    return new DescribeBlock(description, IsOnly: false, IsSkipped: false, lineNumber, filePath);
   }
 
   /// <summary>
   /// A builder object for creating nested test suites using a fluent syntax.
   /// </summary>
   /// <param name="Description">The description for the block of tests.</param>
-  public record DescribeBlock(string Description)
+  public record DescribeBlock(
+    string Description,
+    bool IsOnly,
+    bool IsSkipped,
+    int LineNumber,
+    string FilePath
+  )
   {
     /// <summary>
     /// Describes a suite of tests within the current scope.
@@ -111,9 +70,94 @@ public static partial class TestBuilder
     /// <param name="body">An action containing the tests to run in this scope.</param>
     public void As(Action body)
     {
+      var scopeIndex = CurrentScope?.Children.Count ?? 0;
+      var metadata = new TestMetadata(
+        Description: Description,
+        ScopeIndex: scopeIndex,
+        LineNumber: LineNumber,
+        FilePath: FilePath,
+        IsOnly: IsOnly,
+        IsSkipped: IsSkipped
+      );
+      if (RootScope == null)
+      {
+        CurrentScope = new TestScope(null, metadata);
+        RootScope = CurrentScope;
+      }
+      else
+      {
+        var parent = CurrentScope;
+        CurrentScope = new TestScope(parent, metadata);
+        parent?.Children.Add(CurrentScope);
+      }
+
       body();
       // Pop back to the parent scope after running all the inner scopes
       CurrentScope = CurrentScopeNotNull.Parent;
+    }
+
+    /// <summary>
+    /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
+    /// Use <see cref="As(Action)"/> instead.
+    /// </summary>
+    /// <param name="body"></param>
+    /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
+    [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+    public void As(Func<Task> body)
+    {
+      throw new InvalidOperationException(InvalidDescribeAsyncMethodCallMessage);
+    }
+  }
+
+  /// <summary>
+  /// Adds a test to the current scope, configured with a fluent API.
+  /// </summary>
+  /// <param name="Values">The values to enumerate. A Describe block will be generated for every element in the list.</param>
+  /// <param name="Description">The description of the tests. This supports a format string taking</param>
+  /// <param name="IsOnly">Should be the only test run in the suite</param>
+  /// <param name="IsSkipped">Should be skipped</param>
+  /// <param name="LineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="FilePath">Leave unset, used by the runtime to support running tests via the IDE</param>
+  public record DescribeEachBlock<T>(
+    IEnumerable<T> Values,
+    Func<T, string> Description,
+    bool IsOnly,
+    bool IsSkipped,
+    int LineNumber,
+    string FilePath
+  )
+  {
+    /// <summary>
+    /// Describes the test body.
+    /// This will run when the test is executed.
+    /// </summary>
+    /// <param name="body">The test body. Assertions should go in here.</param>
+    public void As(Action<T> body)
+    {
+      foreach (var value in Values)
+      {
+        // Capture the value in a local variable to avoid it changing in the closure
+        var val = value;
+        new DescribeBlock(
+          Description: Description(val),
+          LineNumber: LineNumber,
+          FilePath: FilePath,
+          IsOnly: IsOnly,
+          IsSkipped: IsSkipped
+        ).As(() => body(val));
+      }
+    }
+
+    /// <summary>
+    /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
+    /// Use <see cref="As(Action{T})"/> instead.
+    /// </summary>
+    /// <param name="body"></param>
+    /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
+    [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+    public void As(Func<T, Task> body)
+    {
+      throw new InvalidOperationException(InvalidDescribeAsyncMethodCallMessage);
     }
   }
 }

--- a/Detestable/TestBuilder.Describe.cs
+++ b/Detestable/TestBuilder.Describe.cs
@@ -2,10 +2,6 @@
 
 namespace Detestable;
 
-/// <summary>
-/// Provides methods for building test suites using a declarative syntax.
-/// Generally should be used with the <c>using static Detestable.TestBuilder</c> directive.
-/// </summary>
 public static partial class TestBuilder
 {
   internal const string InvalidDescribeAsyncMethodCallMessage = """
@@ -21,7 +17,7 @@ public static partial class TestBuilder
   /// <param name="description"></param>
   /// <param name="body"></param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
   public static void Describe(string description, Func<Task> body) =>
     throw new InvalidOperationException(InvalidDescribeAsyncMethodCallMessage);
 
@@ -31,6 +27,8 @@ public static partial class TestBuilder
   /// </summary>
   /// <param name="description">The description of this block of the test suite.</param>
   /// <param name="body">A callback which is immediately invoked to describe tests</param>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Describe(
     string description,
     Action body,
@@ -39,10 +37,12 @@ public static partial class TestBuilder
   ) => Describe(description, lineNumber, filePath).As(body);
 
   /// <summary>
-  /// Describes a suite of tests using a fluent syntax.  Specify the body of the suite using the <see cref="DescribeBlock.As" /> method.
+  /// Describes a suite of tests using a fluent syntax.  Specify the body of the suite using the <see cref="DescribeBlock.As(Action)" /> method.
   /// </summary>
   /// <param name="description">The description of this block of the test suite.</param>
   /// <returns>A <see cref="DescribeBlock" /> object which allows for the creation of nested test suites.</returns>
+  /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeBlock Describe(
     string description,
     [CallerLineNumber] int lineNumber = 0,
@@ -56,6 +56,10 @@ public static partial class TestBuilder
   /// A builder object for creating nested test suites using a fluent syntax.
   /// </summary>
   /// <param name="Description">The description for the block of tests.</param>
+  /// <param name="IsOnly">Should be the only test run in the suite</param>
+  /// <param name="IsSkipped">Should be skipped</param>
+  /// <param name="LineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
+  /// <param name="FilePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public record DescribeBlock(
     string Description,
     bool IsOnly,
@@ -102,7 +106,7 @@ public static partial class TestBuilder
     /// </summary>
     /// <param name="body"></param>
     /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-    [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+    [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
     public void As(Func<Task> body)
     {
       throw new InvalidOperationException(InvalidDescribeAsyncMethodCallMessage);
@@ -154,7 +158,7 @@ public static partial class TestBuilder
     /// </summary>
     /// <param name="body"></param>
     /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-    [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
+    [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
     public void As(Func<T, Task> body)
     {
       throw new InvalidOperationException(InvalidDescribeAsyncMethodCallMessage);

--- a/Detestable/TestBuilder.Describe.cs
+++ b/Detestable/TestBuilder.Describe.cs
@@ -1,4 +1,6 @@
-﻿namespace Detestable;
+﻿using System.Runtime.CompilerServices;
+
+namespace Detestable;
 
 /// <summary>
 /// Provides methods for building test suites using a declarative syntax.
@@ -8,7 +10,7 @@ public static partial class TestBuilder
 {
   /// <summary>
   /// Obsolete. Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
-  /// Use <see cref="Describe(string,Action)"/> instead.
+  /// Use <see cref="Describe(string,Action,int,string)"/> instead.
   /// </summary>
   /// <param name="description"></param>
   /// <param name="body"></param>
@@ -29,17 +31,31 @@ public static partial class TestBuilder
   /// </summary>
   /// <param name="description">The description of this block of the test suite.</param>
   /// <param name="body">A callback which is immediately invoked to describe tests</param>
-  public static void Describe(string description, Action body)
+  public static void Describe(
+    string description,
+    Action body,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  )
   {
+    var scopeIndex = CurrentScope?.Children.Count ?? 0;
+    var metadata = new TestMetadata(
+      description,
+      scopeIndex,
+      lineNumber,
+      filePath,
+      IsOnly: false,
+      IsSkipped: false
+    );
     if (RootScope == null)
     {
-      CurrentScope = new TestScope(description, null);
+      CurrentScope = new TestScope(description, null, metadata);
       RootScope = CurrentScope;
     }
     else
     {
       var parent = CurrentScope;
-      CurrentScope = new TestScope(description, parent);
+      CurrentScope = new TestScope(description, parent, metadata);
       parent?.Children.Add(CurrentScope);
     }
 
@@ -53,17 +69,30 @@ public static partial class TestBuilder
   /// </summary>
   /// <param name="description">The description of this block of the test suite.</param>
   /// <returns>A <see cref="DescribeBlock" /> object which allows for the creation of nested test suites.</returns>
-  public static DescribeBlock Describe(string description)
+  public static DescribeBlock Describe(
+    string description,
+    [CallerLineNumber] int lineNumber = 0,
+    [CallerFilePath] string filePath = ""
+  )
   {
+    var scopeIndex = CurrentScope?.Children.Count ?? 0;
+    var metadata = new TestMetadata(
+      description,
+      scopeIndex,
+      lineNumber,
+      filePath,
+      IsOnly: false,
+      IsSkipped: false
+    );
     if (RootScope == null)
     {
-      CurrentScope = new TestScope(description, null);
+      CurrentScope = new TestScope(description, null, metadata);
       RootScope = CurrentScope;
     }
     else
     {
       var parent = CurrentScope;
-      CurrentScope = new TestScope(description, parent);
+      CurrentScope = new TestScope(description, parent, metadata);
       parent?.Children.Add(CurrentScope);
     }
 

--- a/Detestable/TestBuilder.It.cs
+++ b/Detestable/TestBuilder.It.cs
@@ -2,7 +2,6 @@
 
 namespace Detestable;
 
-#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters - we need them to get the line number and file path of the caller
 /// <summary>
 /// Provides methods for building test suites using a declarative syntax.
 /// Generally should be used with the <c>using static Detestable.TestBuilder</c> directive.
@@ -50,7 +49,7 @@ public static partial class TestBuilder
     string description,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => new(description, lineNumber, filePath);
+  ) => new(description, lineNumber, filePath, false);
 
   /// <summary>
   /// Adds a test to the current scope, configured with a fluent API.
@@ -58,7 +57,8 @@ public static partial class TestBuilder
   /// <param name="Description">The description of the test</param>
   /// <param name="LineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="FilePath">Leave unset, used by the runtime to support running tests via the IDE</param>
-  public record ItBlock(string Description, int LineNumber, string FilePath)
+  /// <param name="IsOnly">Should be the only test run in the suite</param>
+  public record ItBlock(string Description, int LineNumber, string FilePath, bool IsOnly)
   {
     /// <summary>
     /// Describes the test body.
@@ -87,11 +87,11 @@ public static partial class TestBuilder
           Description: Description,
           ScopeIndex: CurrentScopeNotNull.TestMethods.Count,
           LineNumber: LineNumber,
-          FilePath: FilePath
+          FilePath: FilePath,
+          IsOnly: IsOnly
         )
       );
       CurrentScopeNotNull.TestMethods.Add(tm);
     }
   }
 }
-#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters

--- a/Detestable/TestBuilder.It.cs
+++ b/Detestable/TestBuilder.It.cs
@@ -2,10 +2,6 @@
 
 namespace Detestable;
 
-/// <summary>
-/// Provides methods for building test suites using a declarative syntax.
-/// Generally should be used with the <c>using static Detestable.TestBuilder</c> directive.
-/// </summary>
 public static partial class TestBuilder
 {
   /// <summary>
@@ -106,14 +102,15 @@ public static partial class TestBuilder
   /// <summary>
   /// Adds a test to the current scope, configured with a fluent API.
   /// </summary>
-  /// <param name="Description">The description of the tests. This supports a format string taking</param>
+  /// <param name="Values">The values to enumerate. An It block will be generated for every element in the list.</param>
+  /// <param name="DescriptionResolver">A callback function to generate the description of the tests.  It is passed each value from <paramref name="Values"/></param>
   /// <param name="IsOnly">Should be the only test run in the suite</param>
   /// <param name="IsSkipped">Should be skipped</param>
   /// <param name="LineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="FilePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public record ItEachBlock<T>(
     IEnumerable<T> Values,
-    Func<T, string> Description,
+    Func<T, string> DescriptionResolver,
     bool IsOnly,
     bool IsSkipped,
     int LineNumber,
@@ -149,7 +146,7 @@ public static partial class TestBuilder
         var tm = new TestBlock(
           () => body(val),
           new(
-            Description: Description(val),
+            Description: DescriptionResolver(val),
             ScopeIndex: CurrentScopeNotNull.TestMethods.Count,
             LineNumber: LineNumber,
             FilePath: FilePath,

--- a/Detestable/TestBuilder.cs
+++ b/Detestable/TestBuilder.cs
@@ -7,10 +7,10 @@
 public static partial class TestBuilder
 {
   [ThreadStatic]
-  private static TestScope? CurrentScope;
+  internal static TestScope? CurrentScope;
 
   [ThreadStatic]
-  private static TestScope? RootScope;
+  internal static TestScope? RootScope;
 
   internal static TestScope ConsumeRootScope()
   {
@@ -23,7 +23,7 @@ public static partial class TestBuilder
     return rs;
   }
 
-  private static TestScope CurrentScopeNotNull =>
+  internal static TestScope CurrentScopeNotNull =>
     CurrentScope
     ?? throw new InvalidOperationException("No current scope. Has Describe been called?");
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,7 +19,7 @@
     <PackageReleaseNotes>
       Initial release
     </PackageReleaseNotes>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     </PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,25 +1,28 @@
 <Project>
     <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Version>0.0.6</Version>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <Authors>Liam Morrow</Authors>
-    <Title>
-      Detestable
-    </Title>
-    <Description>
-      An Xunit extension for c# that allows for more readable tests, heavily inspired by Jest
-    </Description>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <IncludeSource>true</IncludeSource>
-    <RepositoryUrl>https://github.com/LiamMorrow/Detestable</RepositoryUrl>
-    <PackageReleaseNotes>
-      Initial release
-    </PackageReleaseNotes>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+      <TargetFramework>net8.0</TargetFramework>
+      <Version>0.0.6</Version>
+      <ImplicitUsings>enable</ImplicitUsings>
+      <Nullable>enable</Nullable>
+      <Authors>Liam Morrow</Authors>
+      <Title>
+        Detestable
+      </Title>
+      <Description>
+        An Xunit extension for c# that allows for more readable tests, heavily inspired by Jest
+      </Description>
+      <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+      <IncludeSymbols>true</IncludeSymbols>
+      <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+      <IncludeSource>true</IncludeSource>
+      <RepositoryUrl>https://github.com/LiamMorrow/Detestable</RepositoryUrl>
+      <PackageReleaseNotes>
+        Initial release
+      </PackageReleaseNotes>
+      <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -138,6 +138,23 @@ Describe("My test suite")
     })
 ```
 
+## Features
+
+### Type Safe Test Enumeration
+
+Providing tests with dynamic data has next to zero ceremony. There's no need to annotate with a method with `[Theory]`, or supply data through a different class / member with `[MemberData]`, which has many pitfalls and moves the information of the test far from it. Simply use an `It.Each` or a `Describe.Each` method call and provide the data directly.
+
+```cs
+
+It.Each(
+    [1, 3, 5],
+    val => $"{val} is odd" // Format string are supported as well: "{0} is odd",
+    (value)=>
+    {
+        (value % 2).Should().Be(1);
+    });
+```
+
 ### Examples
 
 See the [Detestable.Tests package](./Detestable.Tests/) for examples of how tests can be written. All tests for Detestable are written in it!


### PR DESCRIPTION
## Each
Describing multiple tests which only vary slightly based on some data can now be done via the `Describe.Each` and `It.Each` methods.  These accept an `IEnumerable<T>`, and will generate a test for every element in the collection.  The test body will get passed the value as an argument.

## Skip
It is now possible to skip a test or an entire describe block by calling the `It.Skip` / `Describe.Skip` methods.  This allows the test to exist, but to be skipped for whatever reason (maybe it is slow and you don't want to run it for now)

## Only
The inverse to `Skip`, using `Describe.Only` or `It.Only` means that that test or block of tests will be the only tests that run within the spec, other tests in the spec will be skipped.  Note this does not affect tests in OTHER specs (if you have multiple `[Describe]` or `[Fact]`s they will be unaffected)

