### PR TITLE
Allow configuration of timeout

### DIFF
--- a/Oatmilk/Internal/OatmilkConfiguration.cs
+++ b/Oatmilk/Internal/OatmilkConfiguration.cs
@@ -1,0 +1,9 @@
+namespace Oatmilk.Internal;
+
+internal static class OatmilkConfiguration
+{
+  public static TimeSpan DefaultTimeout { get; set; } =
+    Environment.GetEnvironmentVariable("OATMILK_DEFAULT_TIMEOUT_SECONDS") is string timeoutString
+      ? TimeSpan.FromSeconds(int.Parse(timeoutString))
+      : TimeSpan.FromSeconds(5);
+}

--- a/Oatmilk/TestBuilder.cs
+++ b/Oatmilk/TestBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace Oatmilk;
+﻿using Oatmilk.Internal;
+
+namespace Oatmilk;
 
 /// <summary>
 /// Provides methods for building test suites using a declarative syntax.
@@ -14,8 +16,9 @@ public static partial class TestBuilder
 
   /// <summary>
   /// The default timeout for tests. Defaults to 5 seconds.
+  /// Can be configured by setting the OATMILK_DEFAULT_TIMEOUT_SECONDS environment variable.
   /// </summary>
-  public static TimeSpan DefaultTimeout { get; } = TimeSpan.FromSeconds(5);
+  public static TimeSpan DefaultTimeout { get; } = OatmilkConfiguration.DefaultTimeout;
 
   internal static TestScope ConsumeRootScope()
   {


### PR DESCRIPTION
The default timeout of 5 seconds can be overridden by setting the OATMILK_DEFAULT_TIMEOUT_SECONDS env var