### PR TITLE
Add tests using the variants of the describe method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 obj
 bin
+TestResults

--- a/Oatmilk.Tests/MultiArgUnitTestsExample.cs
+++ b/Oatmilk.Tests/MultiArgUnitTestsExample.cs
@@ -24,11 +24,12 @@ public class MultiArgUnitTestsExample
           "Should pass",
           async () =>
           {
-            await Task.Delay(TimeSpan.FromSeconds(5));
+            await Task.Delay(TimeSpan.FromMilliseconds(20));
             Assert.True(true);
           },
-          timeout: TimeSpan.FromSeconds(10)
+          timeout: TimeSpan.FromMilliseconds(100)
         );
+
         It.Each<object>(
           [1, 2, 3, 15, "d", "hello", "world"],
           "Should pass for {0:x}",

--- a/Oatmilk.Tests/Oatmilk.Tests.csproj
+++ b/Oatmilk.Tests/Oatmilk.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Oatmilk.Tests/TestBuilderTests.cs
+++ b/Oatmilk.Tests/TestBuilderTests.cs
@@ -65,8 +65,8 @@ public class TestBuilderTests
               () =>
               {
                 var rootScope = TestBuilder.ConsumeRootScope();
-                rootScope.TestMethods.Should().HaveCount(1);
-                rootScope.TestMethods.Single().Metadata.Description.Should().Be("top level it");
+                rootScope.TestBlocks.Should().HaveCount(1);
+                rootScope.TestBlocks.Single().Metadata.Description.Should().Be("top level it");
               }
             );
           }
@@ -95,11 +95,11 @@ public class TestBuilderTests
               () =>
               {
                 var rootScope = TestBuilder.ConsumeRootScope();
-                rootScope.TestMethods.Should().HaveCount(0);
+                rootScope.TestBlocks.Should().HaveCount(0);
                 rootScope.Children.Should().HaveCount(1);
                 var nestedScope = rootScope.Children.Single();
-                nestedScope.TestMethods.Should().HaveCount(1);
-                nestedScope.TestMethods.Single().Metadata.Description.Should().Be("Nested It");
+                nestedScope.TestBlocks.Should().HaveCount(1);
+                nestedScope.TestBlocks.Single().Metadata.Description.Should().Be("Nested It");
               }
             );
 
@@ -146,13 +146,13 @@ public class TestBuilderTests
               {
                 var rootScope = TestBuilder.ConsumeRootScope();
                 var nestedScope = rootScope.Children.Single();
-                nestedScope.TestMethods.Should().HaveCount(1);
-                nestedScope.TestMethods.Single().Metadata.Description.Should().Be("Nested It");
+                nestedScope.TestBlocks.Should().HaveCount(1);
+                nestedScope.TestBlocks.Single().Metadata.Description.Should().Be("Nested It");
                 nestedScope.Children.Should().HaveCount(1);
                 var doubleNestedScope = nestedScope.Children.Single();
-                doubleNestedScope.TestMethods.Should().HaveCount(1);
+                doubleNestedScope.TestBlocks.Should().HaveCount(1);
                 doubleNestedScope
-                  .TestMethods.Single()
+                  .TestBlocks.Single()
                   .Metadata.Description.Should()
                   .Be("Double Nested It");
               }

--- a/Oatmilk.Tests/TestVariants/DescribeTestVariants.cs
+++ b/Oatmilk.Tests/TestVariants/DescribeTestVariants.cs
@@ -1,0 +1,163 @@
+namespace Oatmilk.Tests.TestVariants;
+
+public class DescribeTestVariants
+{
+  [Describe("A test suite of many of the Describe variants")]
+  public void EachSpec()
+  {
+    It("should pass", () => Assert.True(true));
+
+    Describe.Each(
+      [1, 2, 3],
+      "with a nested block at index {0}",
+      (i) =>
+      {
+        It("should pass for index " + i, () => Assert.True(true));
+      }
+    );
+
+    Describe.Each(
+      ["a", "b", "c"],
+      s => $"with a nested block for string {s}",
+      s =>
+      {
+        It($"should pass for string {s}", () => Assert.True(true));
+      }
+    );
+
+    Describe.Skip(
+      "a skipped suite",
+      () =>
+      {
+        It("should be skipped", () => Assert.True(false));
+
+        Describe(
+          "a nested skipped suite",
+          () =>
+          {
+            It("should be skipped", () => Assert.True(false));
+          }
+        );
+      }
+    );
+    Describe.Skip(
+      [1, 2, 3],
+      "a skipped suite with variants {0}",
+      (i) =>
+      {
+        It("should be skipped", () => Assert.True(false));
+
+        Describe(
+          "a nested skipped suite",
+          () =>
+          {
+            It("should be skipped", () => Assert.True(false));
+          }
+        );
+      }
+    );
+    Describe.Skip(
+      [1, 2, 3],
+      x => $"a skipped suite with variants {x}",
+      (i) =>
+      {
+        It("should be skipped", () => Assert.True(false));
+
+        Describe(
+          "a nested skipped suite",
+          () =>
+          {
+            It("should be skipped", () => Assert.True(false));
+          }
+        );
+      }
+    );
+
+    It(
+      "should throw an error when trying to use the async variants of Describe",
+      () =>
+      {
+#pragma warning disable CS0618
+        Assert.Throws<InvalidOperationException>(
+          () => Describe("A test suite", async () => await Task.CompletedTask)
+        );
+        Assert.Throws<InvalidOperationException>(
+          () => Describe.Each([1], "A test suite", async (a) => await Task.CompletedTask)
+        );
+        Assert.Throws<InvalidOperationException>(
+          () => Describe.Each([1], a => "A test suite" + a, async (a) => await Task.CompletedTask)
+        );
+        Assert.Throws<InvalidOperationException>(
+          () => Describe.Skip("A test suite", async () => await Task.CompletedTask)
+        );
+        Assert.Throws<InvalidOperationException>(
+          () => Describe.Skip([1], "A test suite", async (a) => await Task.CompletedTask)
+        );
+        Assert.Throws<InvalidOperationException>(
+          () => Describe.Skip([1], x => $"A test suite {x}", async (a) => await Task.CompletedTask)
+        );
+        Assert.Throws<InvalidOperationException>(
+          () => Describe.Only("A test suite", async () => await Task.CompletedTask)
+        );
+        Assert.Throws<InvalidOperationException>(
+          () => Describe.Only([1], "A test suite", async (a) => await Task.CompletedTask)
+        );
+        Assert.Throws<InvalidOperationException>(
+          () => Describe.Only([1], x => $"A test suite {x}", async (a) => await Task.CompletedTask)
+        );
+#pragma warning restore CS0618
+      }
+    );
+  }
+
+  [Describe("A test suite containing Describe.Only calls")]
+  public void OnlySpec()
+  {
+    // Note that any describe with an only will be run, not just the first
+    Describe.Only(
+      "Here we have a top level only",
+      () =>
+      {
+        It("should pass", () => Assert.True(true));
+      }
+    );
+
+    Describe.Only(
+      [1, 2, 4],
+      "This is an each using the only method {0}",
+      (i) =>
+      {
+        It("should pass", () => Assert.True(true));
+      }
+    );
+
+    Describe.Only(
+      [1, 2, 4],
+      x => $"This is an each using the only method {x}",
+      (i) =>
+      {
+        It("should pass", () => Assert.True(true));
+      }
+    );
+
+    Describe(
+      "This one does not have an only, so tests inside should be skipped",
+      () =>
+      {
+        It("should be skipped", () => Assert.True(false));
+      }
+    );
+  }
+
+  [Oatmilk]
+  public void Spec2()
+  {
+    Describe(
+      "A test suite with the oatmilk annotation",
+      () =>
+      {
+        It("should pass", () => Assert.True(true));
+      }
+    );
+  }
+}

--- a/Oatmilk.Xunit/Oatmilk.Xunit.csproj
+++ b/Oatmilk.Xunit/Oatmilk.Xunit.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Oatmilk.Tests" />
     <Using Include="Xunit" />
   </ItemGroup>
 </Project>

--- a/Oatmilk.Xunit/OatmilkDiscoverer.cs
+++ b/Oatmilk.Xunit/OatmilkDiscoverer.cs
@@ -31,29 +31,32 @@ internal class OatmilkDiscoverer : IXunitTestCaseDiscoverer
     TestScope testScope,
     ITestMethod callingMethod,
     bool anyOnlyTestsInEntireScope
-  )
-  {
-    foreach (var testMethod in testScope.TestMethods)
-    {
-      yield return new OatmilkXunitTestCase(
-        testScope,
-        testMethod,
+  ) =>
+    TraverseScopesAndYieldTestBlocks(testScope, anyOnlyTestsInEntireScope)
+      .Select(x => new OatmilkXunitTestCase(
+        x.TestScope,
+        x.TestBlock,
         callingMethod,
         anyOnlyTestsInEntireScope
-      );
+      ));
+
+  internal static IEnumerable<(
+    TestScope TestScope,
+    TestBlock TestBlock
+  )> TraverseScopesAndYieldTestBlocks(TestScope testScope, bool anyOnlyTestsInEntireScope)
+  {
+    foreach (var testBlock in testScope.TestBlocks)
+    {
+      yield return (testScope, testBlock);
     }
 
     foreach (var childScope in testScope.Children)
     {
       foreach (
-        var testCase in TraverseScopesAndYieldTestCases(
-          childScope,
-          callingMethod,
-          anyOnlyTestsInEntireScope
-        )
+        var testBlock in TraverseScopesAndYieldTestBlocks(childScope, anyOnlyTestsInEntireScope)
       )
       {
-        yield return testCase;
+        yield return testBlock;
       }
     }
   }

--- a/Oatmilk.Xunit/OatmilkXunitTestCase.cs
+++ b/Oatmilk.Xunit/OatmilkXunitTestCase.cs
@@ -26,7 +26,7 @@ internal partial class OatmilkXunitTestCase(
     && !TestBlock.Metadata.IsOnly
     && !TestScope.AnyParentsOrThis(x => x.Metadata.IsOnly);
   public string? SkipReason =>
-    TestBlock.Metadata.IsSkipped || TestScope.AnyParentsOrThis(x => x.Metadata.IsSkipped)
+    TestBlock.ShouldSkipDueToIsSkippedOnThisOrParent(TestScope)
       ? "Used a Skip method"
       : SkippingDueToParentScopeOnly
         ? "Only tests are present in this scope"

--- a/Oatmilk.Xunit/OatmilkXunitTestCase.cs
+++ b/Oatmilk.Xunit/OatmilkXunitTestCase.cs
@@ -62,7 +62,7 @@ internal partial class OatmilkXunitTestCase(
   }
 
   public string UniqueID =>
-    $"{TestBlock.Metadata.FilePath}:{TestBlock.Metadata.LineNumber}:{TestBlock.Metadata.ScopeIndex}";
+    $"{TestBlock.Metadata.FilePath}:{TestBlock.Metadata.LineNumber}:{TestScope.ScopeIndexPath}:{TestBlock.Metadata.ScopeIndex}";
 
   public async Task<RunSummary> RunAsync(
     IMessageSink diagnosticMessageSink,

--- a/Oatmilk/Describe.Each.cs
+++ b/Oatmilk/Describe.Each.cs
@@ -109,7 +109,7 @@ public static partial class Describe
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
   public static void Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -131,7 +131,7 @@ public static partial class Describe
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
   public static void Each<T>(
     IEnumerable<T> values,
     Func<T, string> description,

--- a/Oatmilk/Describe.Only.cs
+++ b/Oatmilk/Describe.Only.cs
@@ -138,7 +138,7 @@ public static partial class Describe
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
   public static void Only(
     string description,
     Func<Task> body,
@@ -158,7 +158,7 @@ public static partial class Describe
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
   public static void Only<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -179,7 +179,7 @@ public static partial class Describe
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
   public static void Only<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,

--- a/Oatmilk/Describe.Skip.cs
+++ b/Oatmilk/Describe.Skip.cs
@@ -142,7 +142,7 @@ public static partial class Describe
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
   public static void Skip(
     string description,
     Func<Task> body,
@@ -163,7 +163,7 @@ public static partial class Describe
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
   public static void Skip<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
@@ -185,7 +185,7 @@ public static partial class Describe
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
   public static void Skip<T>(
     IEnumerable<T> values,
     Func<T, string> description,

--- a/Oatmilk/Internal/IOatmilkMessageBus.cs
+++ b/Oatmilk/Internal/IOatmilkMessageBus.cs
@@ -33,3 +33,42 @@ internal interface IOatmilkMessageBus
   void OnAfterTestSetupStarting(TestBlock testBlock, TestScope testScope);
   void OnAfterTestSetupFinished(TestBlock testBlock, TestScope testScope);
 }
+
+internal class DummyMessageBus : IOatmilkMessageBus
+{
+  public void OnBeforeTestSetupStarting(TestBlock testBlock, TestScope testScope) { }
+
+  public void OnBeforeTestSetupFinished(TestBlock testBlock, TestScope testScope) { }
+
+  public void OnTestFailed(
+    TestBlock testBlock,
+    TestScope testScope,
+    Exception ex,
+    TimeSpan executionTime,
+    string output
+  ) { }
+
+  public void OnTestFinished(
+    TestBlock testBlock,
+    TestScope testScope,
+    TimeSpan executionTime,
+    string output
+  ) { }
+
+  public void OnTestOutput(TestBlock testBlock, TestScope testScope, string output) { }
+
+  public void OnTestPassed(
+    TestBlock testBlock,
+    TestScope testScope,
+    TimeSpan executionTime,
+    string output
+  ) { }
+
+  public void OnTestSkipped(TestBlock testBlock, TestScope testScope, string reason) { }
+
+  public void OnTestStarting(TestBlock testBlock, TestScope testScope) { }
+
+  public void OnAfterTestSetupStarting(TestBlock testBlock, TestScope testScope) { }
+
+  public void OnAfterTestSetupFinished(TestBlock testBlock, TestScope testScope) { }
+}

--- a/Oatmilk/Internal/OatmilkRunSummary.cs
+++ b/Oatmilk/Internal/OatmilkRunSummary.cs
@@ -6,17 +6,4 @@ internal record OatmilkRunSummary(
   int Failed = 0,
   int Skipped = 0,
   TimeSpan Time = default
-)
-{
-  public OatmilkRunSummary Aggregate(OatmilkRunSummary runSummary)
-  {
-    return this with
-    {
-      Total = Total + runSummary.Total,
-      Passed = Passed + runSummary.Passed,
-      Failed = Failed + runSummary.Failed,
-      Skipped = Skipped + runSummary.Skipped,
-      Time = Time + runSummary.Time
-    };
-  }
-}
+);

--- a/Oatmilk/Internal/OatmilkTestBlockRunner.cs
+++ b/Oatmilk/Internal/OatmilkTestBlockRunner.cs
@@ -23,7 +23,7 @@ internal class OatmilkTestBlockRunner(
       messageBus.OnTestSkipped(testBlock, testScope, "Parent scope has an only block");
       return result with { Skipped = 1 };
     }
-    if (testBlock.Metadata.IsSkipped || testScope.AnyParentsOrThis(x => x.Metadata.IsSkipped))
+    if (testBlock.ShouldSkipDueToIsSkippedOnThisOrParent(testScope))
     {
       messageBus.OnTestSkipped(testBlock, testScope, "Skipped using a Skip method");
       return result with { Skipped = 1 };

--- a/Oatmilk/Internal/OatmilkTestBlockRunner.cs
+++ b/Oatmilk/Internal/OatmilkTestBlockRunner.cs
@@ -17,11 +17,6 @@ internal class OatmilkTestBlockRunner(
     var testInput = new TestInput(testOutputSink, tokenTimeout.Token);
 
     var result = new OatmilkRunSummary(Total: 1);
-    if (testBlock.Metadata.IsSkipped || testScope.AnyParentsOrThis(s => s.Metadata.IsSkipped))
-    {
-      messageBus.OnTestSkipped(testBlock, testScope, "Test or enclosing scope is skipped");
-      return result with { Skipped = 1 };
-    }
 
     var sw = Stopwatch.StartNew();
 
@@ -44,7 +39,7 @@ internal class OatmilkTestBlockRunner(
         );
       }
       await testRun;
-      result = result with { Time = sw.Elapsed };
+      result = result with { Time = sw.Elapsed, Passed = 1 };
       messageBus.OnTestPassed(testBlock, testScope, result.Time, testOutputSink.GetOutput().Output);
     }
     catch (Exception ex)

--- a/Oatmilk/Internal/TestDescription.cs
+++ b/Oatmilk/Internal/TestDescription.cs
@@ -88,6 +88,21 @@ internal record TestMetadata(
 
 internal record TestBlock(Func<TestInput, Task> Body, TestMetadata Metadata)
 {
+  public bool ShouldSkipDueToIsSkippedOnThisOrParent(TestScope scope)
+  {
+    if (Metadata.IsSkipped)
+    {
+      return true;
+    }
+
+    if (scope.AnyParentsOrThis(x => x.Metadata.IsSkipped))
+    {
+      return true;
+    }
+
+    return false;
+  }
+
   public string GetDescription(TestScope scope)
   {
     var sb = new StringBuilder();

--- a/Oatmilk/Internal/TestDescription.cs
+++ b/Oatmilk/Internal/TestDescription.cs
@@ -13,6 +13,11 @@ internal record TestScope(TestScope? Parent, TestMetadata Metadata)
   internal List<TestBlock> TestMethods { get; } = [];
   internal List<TestScope> Children { get; } = [];
 
+  internal string ScopeIndexPath =>
+    Parent == null
+      ? Metadata.ScopeIndex.ToString()
+      : $"{Parent.ScopeIndexPath}.{Metadata.ScopeIndex}";
+
   internal bool AnyParentsOrThis(Func<TestScope, bool> predicate)
   {
     var current = this;

--- a/Oatmilk/Internal/TestDescription.cs
+++ b/Oatmilk/Internal/TestDescription.cs
@@ -10,7 +10,7 @@ internal record TestScope(TestScope? Parent, TestMetadata Metadata)
   internal List<TestSetupMethod> TestBeforeEachs { get; } = [];
   internal List<TestAfterEachMethod> TestAfterEachs { get; } = [];
   internal List<TestTeardownMethod> TestAfterAlls { get; } = [];
-  internal List<TestBlock> TestMethods { get; } = [];
+  internal List<TestBlock> TestBlocks { get; } = [];
   internal List<TestScope> Children { get; } = [];
 
   internal string ScopeIndexPath =>
@@ -52,7 +52,7 @@ internal record TestScope(TestScope? Parent, TestMetadata Metadata)
 
   internal IEnumerable<(TestBlock TestBlock, TestScope TestScope)> EnumerateTests()
   {
-    foreach (var test in TestMethods)
+    foreach (var test in TestBlocks)
     {
       yield return (test, this);
     }
@@ -67,7 +67,7 @@ internal record TestScope(TestScope? Parent, TestMetadata Metadata)
   }
 
   internal bool AnyScopesOrTestsAreOnly =>
-    AnyChildrenOrThis(sc => sc.Metadata.IsOnly || sc.TestMethods.Any(tm => tm.Metadata.IsOnly));
+    AnyChildrenOrThis(sc => sc.Metadata.IsOnly || sc.TestBlocks.Any(tm => tm.Metadata.IsOnly));
 }
 
 internal record TestSetupMethod(Func<TestInput, Task> Body);

--- a/Oatmilk/TestBuilder.Describe.cs
+++ b/Oatmilk/TestBuilder.Describe.cs
@@ -18,7 +18,7 @@ public static partial class TestBuilder
   /// <param name="body"></param>
   /// <param name="timeout"></param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-  [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
+  [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
   public static void Describe(string description, Func<Task> body, TimeSpan? timeout = null) =>
     throw new InvalidOperationException(InvalidDescribeAsyncMethodCallMessage);
 
@@ -121,7 +121,7 @@ public static partial class TestBuilder
     /// </summary>
     /// <param name="body"></param>
     /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-    [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
+    [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
     public void As(Func<Task> body)
     {
       throw new InvalidOperationException(InvalidDescribeAsyncMethodCallMessage);
@@ -176,7 +176,7 @@ public static partial class TestBuilder
     /// </summary>
     /// <param name="body"></param>
     /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
-    [Obsolete(InvalidDescribeAsyncMethodCallMessage, error: true)]
+    [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
     public void As(Func<T, Task> body)
     {
       throw new InvalidOperationException(InvalidDescribeAsyncMethodCallMessage);

--- a/Oatmilk/TestBuilder.It.cs
+++ b/Oatmilk/TestBuilder.It.cs
@@ -149,7 +149,7 @@ public static partial class TestBuilder
         body,
         new(
           Description: Description,
-          ScopeIndex: CurrentScopeNotNull.TestMethods.Count,
+          ScopeIndex: CurrentScopeNotNull.TestBlocks.Count,
           LineNumber: LineNumber,
           FilePath: FilePath,
           IsOnly: IsOnly,
@@ -157,7 +157,7 @@ public static partial class TestBuilder
           Timeout: Timeout ?? CurrentScopeNotNull.Metadata.Timeout
         )
       );
-      CurrentScopeNotNull.TestMethods.Add(tm);
+      CurrentScopeNotNull.TestBlocks.Add(tm);
     }
   }
 
@@ -237,7 +237,7 @@ public static partial class TestBuilder
           (testInput) => body(val, testInput),
           new(
             Description: DescriptionResolver(val),
-            ScopeIndex: CurrentScopeNotNull.TestMethods.Count,
+            ScopeIndex: CurrentScopeNotNull.TestBlocks.Count,
             LineNumber: LineNumber,
             FilePath: FilePath,
             IsOnly: IsOnly,
@@ -245,7 +245,7 @@ public static partial class TestBuilder
             Timeout: Timeout ?? CurrentScopeNotNull.Metadata.Timeout
           )
         );
-        CurrentScopeNotNull.TestMethods.Add(tm);
+        CurrentScopeNotNull.TestBlocks.Add(tm);
       }
     }
   }


### PR DESCRIPTION
There are many variants of tests, (Describe/It).Each/Skip/Only.

This PR adds a test for each of these variants, to make sure they work as expected.

Nothing major, just asserting skipped ones fail, and others register properly and pass immediately.

Better tests might be to rest the testrunner /discoverer itself...