### PR TITLE
Replace the raw timeout with a testoptions struct

### DIFF
--- a/Oatmilk.Tests/MultiArgUnitTestsExample.cs
+++ b/Oatmilk.Tests/MultiArgUnitTestsExample.cs
@@ -27,7 +27,7 @@ public class MultiArgUnitTestsExample
             await Task.Delay(TimeSpan.FromMilliseconds(20));
             Assert.True(true);
           },
-          timeout: TimeSpan.FromMilliseconds(100)
+          new(Timeout: TimeSpan.FromMilliseconds(100))
         );
 
         It.Each<object>(

--- a/Oatmilk.Xunit/DescribeDiscoverer.cs
+++ b/Oatmilk.Xunit/DescribeDiscoverer.cs
@@ -32,7 +32,7 @@ public sealed class DescribeAttribute(
 {
   /// <summary>
   /// The description of the test suite.
-  /// This is passed to the <see cref="TestBuilder.Describe(string, Action, TimeSpan?, int,string)"/> method.
+  /// This is passed to the <see cref="TestBuilder.Describe(string, Action, TestOptions, int,string)"/> method.
   /// </summary>
   public string Description { get; } = Description;
 
@@ -47,7 +47,7 @@ public sealed class DescribeAttribute(
   public int LineNumber { get; } = LineNumber;
 
   /// <inheritdoc/>
-  public override int Timeout { get; set; } = TestBuilder.DefaultTimeout.Seconds;
+  public override int Timeout { get; set; } = (int)TestBuilder.DefaultTimeout.TotalSeconds;
 }
 
 internal class DescribeDiscoverer : OatmilkDiscoverer
@@ -59,7 +59,7 @@ internal class DescribeDiscoverer : OatmilkDiscoverer
     TestBuilder.Describe(
       attribute.GetNamedArgument<string>("Description"),
       () => tm.Method.ToRuntimeMethod().Invoke(instance, null),
-      TimeSpan.FromSeconds(timeoutSeconds),
+      new TestOptions(TimeSpan.FromSeconds(timeoutSeconds)),
       attribute.GetNamedArgument<int>(nameof(DescribeAttribute.LineNumber)),
       attribute.GetNamedArgument<string>(nameof(DescribeAttribute.FileName))
     );

--- a/Oatmilk.Xunit/Oatmilk.Xunit.csproj
+++ b/Oatmilk.Xunit/Oatmilk.Xunit.csproj
@@ -6,6 +6,7 @@
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Oatmilk.Xunit/OatmilkXunitTestCase.cs
+++ b/Oatmilk.Xunit/OatmilkXunitTestCase.cs
@@ -114,8 +114,10 @@ internal partial class OatmilkXunitTestCase(
       TestBuilder.Describe(
         describeAttribute.GetNamedArgument<string>(nameof(DescribeAttribute.Description)),
         () => TestMethod.Method.ToRuntimeMethod().Invoke(instance, null),
-        TimeSpan.FromSeconds(
-          describeAttribute.GetNamedArgument<int>(nameof(DescribeAttribute.Timeout))
+        new TestOptions(
+          TimeSpan.FromSeconds(
+            describeAttribute.GetNamedArgument<int>(nameof(DescribeAttribute.Timeout))
+          )
         ),
         describeAttribute.GetNamedArgument<int>(nameof(DescribeAttribute.LineNumber)),
         describeAttribute.GetNamedArgument<string>(nameof(DescribeAttribute.FileName))

--- a/Oatmilk.Xunit/XunitOatmilkMessageBus.cs
+++ b/Oatmilk.Xunit/XunitOatmilkMessageBus.cs
@@ -52,13 +52,6 @@ internal class XunitOatmilkMessageBus(IMessageBus messageBus, IXunitTestCase xun
     );
   }
 
-  public void OnTestOutput(TestBlock testBlock, TestScope testScope, string output)
-  {
-    messageBus.QueueMessage(
-      new global::Xunit.Sdk.TestOutput(GetTest(testBlock, testScope), output)
-    );
-  }
-
   public void OnTestPassed(
     TestBlock testBlock,
     TestScope testScope,
@@ -81,6 +74,6 @@ internal class XunitOatmilkMessageBus(IMessageBus messageBus, IXunitTestCase xun
     messageBus.QueueMessage(new TestStarting(GetTest(testBlock, testScope)));
   }
 
-  private ITest GetTest(TestBlock testBlock, TestScope testScope) =>
-    new XunitTest(xunitTestMethod, testBlock.GetDescription(testScope));
+  private XunitTest GetTest(TestBlock testBlock, TestScope testScope) =>
+    new(xunitTestMethod, testBlock.GetDescription(testScope));
 }

--- a/Oatmilk/Describe.Each.cs
+++ b/Oatmilk/Describe.Each.cs
@@ -12,17 +12,17 @@ public static partial class Describe
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, descriptionFormatString, timeout, lineNumber, filePath).As(body);
+  ) => Each(values, descriptionFormatString, testOptions, lineNumber, filePath).As(body);
 
   /// <summary>
   /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
@@ -31,17 +31,17 @@ public static partial class Describe
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is given.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, descriptionResolver, timeout, lineNumber, filePath).As(body);
+  ) => Each(values, descriptionResolver, testOptions, lineNumber, filePath).As(body);
 
   /// <summary>
   /// A fluent api for creating a suite of tests for every element in the <paramref name="values"/> collection.
@@ -49,13 +49,13 @@ public static partial class Describe
   /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeEachBlock<T> Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
@@ -64,7 +64,7 @@ public static partial class Describe
       v => SafeFormat(descriptionFormatString, v),
       IsOnly: false,
       IsSkipped: false,
-      Timeout: timeout,
+      TestOptions: testOptions,
       lineNumber,
       filePath
     );
@@ -75,13 +75,13 @@ public static partial class Describe
   /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeEachBlock<T> Each<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
@@ -90,7 +90,7 @@ public static partial class Describe
       descriptionResolver,
       IsOnly: false,
       IsSkipped: false,
-      Timeout: timeout,
+      TestOptions: testOptions,
       lineNumber,
       filePath
     );
@@ -99,13 +99,13 @@ public static partial class Describe
 
   /// <summary>
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
-  /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},TimeSpan?,int,string)"/> instead.
+  /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},TestOptions,int,string)"/> instead.
   /// </summary>
   /// <typeparam name="T"></typeparam>
   /// <param name="values"></param>
   /// <param name="descriptionFormatString"></param>
   /// <param name="body"></param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
@@ -114,20 +114,20 @@ public static partial class Describe
     IEnumerable<T> values,
     string descriptionFormatString,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, descriptionFormatString, timeout).As(body);
+  ) => Each(values, descriptionFormatString, testOptions).As(body);
 
   /// <summary>
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
-  /// Use <see cref="Each{T}(IEnumerable{T},Func{T,string},Action{T},TimeSpan?,int,string)"/> instead.
+  /// Use <see cref="Each{T}(IEnumerable{T},Func{T,string},Action{T},TestOptions,int,string)"/> instead.
   /// </summary>
   /// <typeparam name="T"></typeparam>
   /// <param name="values"></param>
   /// <param name="description"></param>
   /// <param name="body"></param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
@@ -136,7 +136,7 @@ public static partial class Describe
     IEnumerable<T> values,
     Func<T, string> description,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) => Each(values, description).As(body);

--- a/Oatmilk/Describe.Only.cs
+++ b/Oatmilk/Describe.Only.cs
@@ -12,17 +12,17 @@ public static partial class Describe
   /// <param name="values">A list of values to pass to the description</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the description. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, descriptionFormatString, timeout, lineNumber, filePath).As(body);
+  ) => Only(values, descriptionFormatString, testOptions, lineNumber, filePath).As(body);
 
   /// <summary>
   /// Creates a suite of tests that will be run exclusively.
@@ -31,44 +31,44 @@ public static partial class Describe
   /// <param name="values">A list of values to pass to the description</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the description. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, descriptionResolver, timeout, lineNumber, filePath).As(body);
+  ) => Only(values, descriptionResolver, testOptions, lineNumber, filePath).As(body);
 
   /// <summary>
   /// Creates a suite of tests that will be run exclusively.
   /// </summary>
   /// <param name="description">The description of the describe block</param>
   /// <param name="body">The method body of the description</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only(
     string description,
     Action body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(description, timeout, lineNumber, filePath).As(body);
+  ) => Only(description, testOptions, lineNumber, filePath).As(body);
 
   /// <summary>
   /// A fluent api for creating a describe block that will be run exclusively.
   /// </summary>
   /// <param name="description">The description of the describe block</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeBlock Only(
     string description,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
@@ -76,7 +76,7 @@ public static partial class Describe
       Description: description,
       IsOnly: true,
       IsSkipped: false,
-      Timeout: timeout,
+      TestOptions: testOptions,
       LineNumber: lineNumber,
       FilePath: filePath
     );
@@ -87,17 +87,17 @@ public static partial class Describe
   /// <typeparam name="T">The type of the data to be passed to the descriptions's body</typeparam>
   /// <param name="values">A list of values to pass to the description</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <returns></returns>
   public static DescribeEachBlock<T> Only<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, x => SafeFormat(descriptionFormatString, x), timeout, lineNumber, filePath);
+  ) => Only(values, x => SafeFormat(descriptionFormatString, x), testOptions, lineNumber, filePath);
 
   /// <summary>
   /// A fluent api for creating a suite of tests that will be run exclusively.
@@ -105,14 +105,14 @@ public static partial class Describe
   /// <typeparam name="T">The type of the data to be passed to the descriptions's body</typeparam>
   /// <param name="values">A list of values to pass to the description</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description. Each value from <paramref name="values"/> is passed to it.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <returns></returns>
   public static DescribeEachBlock<T> Only<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
@@ -121,7 +121,7 @@ public static partial class Describe
       descriptionResolver,
       IsOnly: true,
       IsSkipped: false,
-      Timeout: timeout,
+      TestOptions: testOptions,
       lineNumber,
       filePath
     );
@@ -130,11 +130,11 @@ public static partial class Describe
 
   /// <summary>
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
-  /// Use <see cref="Only(string,Action,TimeSpan?,int,string)"/> instead.
+  /// Use <see cref="Only(string,Action,TestOptions,int,string)"/> instead.
   /// </summary>
   /// <param name="description"></param>
   /// <param name="body"></param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
@@ -142,19 +142,19 @@ public static partial class Describe
   public static void Only(
     string description,
     Func<Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) => Only(description).As(body);
 
   /// <summary>
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
-  /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},TimeSpan?,int,string)"/> instead.
+  /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},TestOptions,int,string)"/> instead.
   /// </summary>
   /// <param name="values"></param>
   /// <param name="descriptionFormatString"></param>
   /// <param name="body"></param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
@@ -163,19 +163,19 @@ public static partial class Describe
     IEnumerable<T> values,
     string descriptionFormatString,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) => Only(values, descriptionFormatString).As(body);
 
   /// <summary>
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
-  /// Use <see cref="Only{T}(IEnumerable{T},Func{T,string},Action{T},TimeSpan?,int,string)"/> instead.
+  /// Use <see cref="Only{T}(IEnumerable{T},Func{T,string},Action{T},TestOptions,int,string)"/> instead.
   /// </summary>
   /// <param name="values"></param>
   /// <param name="descriptionResolver"></param>
   /// <param name="body"></param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
@@ -184,7 +184,7 @@ public static partial class Describe
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) => Only(values, descriptionResolver).As(body);

--- a/Oatmilk/Describe.Skip.cs
+++ b/Oatmilk/Describe.Skip.cs
@@ -15,17 +15,17 @@ public static partial class Describe
   /// <param name="values">A list of values to pass to the description</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the description. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, descriptionFormatString, timeout, lineNumber, filePath).As(body);
+  ) => Skip(values, descriptionFormatString, testOptions, lineNumber, filePath).As(body);
 
   /// <summary>
   /// Creates a suite of tests that will be skipped.
@@ -34,45 +34,45 @@ public static partial class Describe
   /// <param name="values">A list of values to pass to the description</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the description. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, descriptionResolver, timeout, lineNumber, filePath).As(body);
+  ) => Skip(values, descriptionResolver, testOptions, lineNumber, filePath).As(body);
 
   /// <summary>
   /// Creates a suite of tests that will be skipped.
   /// </summary>
   /// <param name="description">The description of the describe block</param>
   /// <param name="body">The method body of the description</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip(
     string description,
     Action body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(description, timeout, lineNumber, filePath).As(body);
+  ) => Skip(description, testOptions, lineNumber, filePath).As(body);
 
   /// <summary>
   /// A fluent api for creating a suite of tests that will be skipped.
   /// See <see cref="DescribeBlock.As(Action)"/>.
   /// </summary>
   /// <param name="description">The description of the describe block</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeBlock Skip(
     string description,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
@@ -80,7 +80,7 @@ public static partial class Describe
       Description: description,
       IsOnly: false,
       IsSkipped: true,
-      Timeout: timeout,
+      TestOptions: testOptions,
       LineNumber: lineNumber,
       FilePath: filePath
     );
@@ -92,16 +92,16 @@ public static partial class Describe
   /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
   /// <param name="values">A list of values to pass to the test description</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeEachBlock<T> Skip<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, x => SafeFormat(descriptionFormatString, x), timeout, lineNumber, filePath);
+  ) => Skip(values, x => SafeFormat(descriptionFormatString, x), testOptions, lineNumber, filePath);
 
   /// <summary>
   /// A fluent api for creating a suite of tests that will be skipped.
@@ -110,13 +110,13 @@ public static partial class Describe
   /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
   /// <param name="values">A list of values to pass to the test description</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static DescribeEachBlock<T> Skip<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
@@ -125,7 +125,7 @@ public static partial class Describe
       descriptionResolver,
       IsOnly: false,
       IsSkipped: true,
-      Timeout: timeout,
+      TestOptions: testOptions,
       lineNumber,
       filePath
     );
@@ -134,11 +134,11 @@ public static partial class Describe
 
   /// <summary>
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
-  /// Use <see cref="Skip(string,Action,TimeSpan?,int,string)"/> instead.
+  /// Use <see cref="Skip(string,Action,TestOptions,int,string)"/> instead.
   /// </summary>
   /// <param name="description"></param>
   /// <param name="body"></param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
@@ -146,20 +146,20 @@ public static partial class Describe
   public static void Skip(
     string description,
     Func<Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) => Skip(description).As(body);
 
   /// <summary>
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
-  /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},TimeSpan?,int,string)"/> instead.
+  /// Use <see cref="Each{T}(IEnumerable{T},string,Action{T},TestOptions,int,string)"/> instead.
   /// </summary>
   /// <typeparam name="T"></typeparam>
   /// <param name="values"></param>
   /// <param name="descriptionFormatString"></param>
   /// <param name="body"></param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
@@ -168,20 +168,20 @@ public static partial class Describe
     IEnumerable<T> values,
     string descriptionFormatString,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) => Skip(values, descriptionFormatString).As(body);
 
   /// <summary>
   /// Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
-  /// Use <see cref="Skip{T}(IEnumerable{T},Func{T,string},Action{T},TimeSpan?,int,string)"/> instead.
+  /// Use <see cref="Skip{T}(IEnumerable{T},Func{T,string},Action{T},TestOptions,int,string)"/> instead.
   /// </summary>
   /// <typeparam name="T"></typeparam>
   /// <param name="values"></param>
   /// <param name="description"></param>
   /// <param name="body"></param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
@@ -190,7 +190,7 @@ public static partial class Describe
     IEnumerable<T> values,
     Func<T, string> description,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) => Skip(values, description).As(body);

--- a/Oatmilk/Internal/IOatmilkMessageBus.cs
+++ b/Oatmilk/Internal/IOatmilkMessageBus.cs
@@ -18,8 +18,6 @@ internal interface IOatmilkMessageBus
     string output
   );
 
-  public void OnTestOutput(TestBlock testBlock, TestScope testScope, string output);
-
   public void OnTestPassed(
     TestBlock testBlock,
     TestScope testScope,
@@ -54,8 +52,6 @@ internal class DummyMessageBus : IOatmilkMessageBus
     TimeSpan executionTime,
     string output
   ) { }
-
-  public void OnTestOutput(TestBlock testBlock, TestScope testScope, string output) { }
 
   public void OnTestPassed(
     TestBlock testBlock,

--- a/Oatmilk/It.Each.cs
+++ b/Oatmilk/It.Each.cs
@@ -12,17 +12,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Action<T, TestInput> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Each(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
@@ -31,17 +31,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Func<T, TestInput, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Each(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
@@ -50,17 +50,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Action<T, TestInput> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Each(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
@@ -69,17 +69,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Func<T, TestInput, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Each(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   ///
 
@@ -90,17 +90,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Each(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
@@ -109,17 +109,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Each(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
@@ -128,17 +128,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Each(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests for every element in the <paramref name="values"/> collection.
@@ -147,17 +147,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Each<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Each(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Each(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// A fluent api for creating a suite of tests for every element in the <paramref name="values"/> collection.
@@ -166,13 +166,13 @@ public static partial class It
   /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItEachBlock<T> Each<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
@@ -181,7 +181,7 @@ public static partial class It
       v => SafeFormat(descriptionFormatString, v),
       IsOnly: false,
       IsSkipped: false,
-      Timeout: timeout,
+      TestOptions: testOptions,
       lineNumber,
       filePath
     );
@@ -193,13 +193,13 @@ public static partial class It
   /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItEachBlock<T> Each<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
@@ -208,7 +208,7 @@ public static partial class It
       descriptionResolver,
       IsOnly: false,
       IsSkipped: false,
-      timeout,
+      testOptions,
       lineNumber,
       filePath
     );

--- a/Oatmilk/It.Only.cs
+++ b/Oatmilk/It.Only.cs
@@ -10,76 +10,76 @@ public static partial class It
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The test body. Assertions should go in here</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only(
     string description,
     Func<Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(description, timeout, lineNumber, filePath).When(body);
+  ) => Only(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a test that will be the only test being run.
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The test body. Assertions should go in here</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only(
     string description,
     Func<TestInput, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(description, timeout, lineNumber, filePath).When(body);
+  ) => Only(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a test that will be the only test being run.
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The test body. Assertions should go in here</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only(
     string description,
     Action body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(description, timeout, lineNumber, filePath).When(body);
+  ) => Only(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a test that will be the only test being run.
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The test body. Assertions should go in here</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only(
     string description,
     Action<TestInput> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(description, timeout, lineNumber, filePath).When(body);
+  ) => Only(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// A fluent api for creating a test that will be the only test being run.
   /// See <see cref="ItBlock.When(Func{Task})"/>.
   /// </summary>
   /// <param name="description">The description of the test</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItBlock Only(
     string description,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
@@ -87,7 +87,7 @@ public static partial class It
       Description: description,
       IsOnly: true,
       IsSkipped: false,
-      Timeout: timeout,
+      TestOptions: testOptions,
       LineNumber: lineNumber,
       FilePath: filePath
     );
@@ -99,17 +99,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Only(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
@@ -118,17 +118,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Action<T, TestInput> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Only(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
@@ -137,17 +137,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Only(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
@@ -156,17 +156,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Func<T, TestInput, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Only(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
@@ -175,17 +175,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Only(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
@@ -194,17 +194,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Action<T, TestInput> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Only(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
@@ -213,17 +213,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Only(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
@@ -232,17 +232,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Only<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Func<T, TestInput, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Only(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Only(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// A fluent api for creating a suite of tests that will be the only tests being run for every element in the <paramref name="values"/> collection.
@@ -251,13 +251,13 @@ public static partial class It
   /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItEachBlock<T> Only<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
@@ -266,7 +266,7 @@ public static partial class It
       v => SafeFormat(descriptionFormatString, v),
       IsOnly: true,
       IsSkipped: false,
-      timeout,
+      testOptions,
       lineNumber,
       filePath
     );
@@ -278,15 +278,23 @@ public static partial class It
   /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItEachBlock<T> Only<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
-    new(values, descriptionResolver, IsOnly: true, IsSkipped: false, timeout, lineNumber, filePath);
+    new(
+      values,
+      descriptionResolver,
+      IsOnly: true,
+      IsSkipped: false,
+      testOptions,
+      lineNumber,
+      filePath
+    );
 }

--- a/Oatmilk/It.Skip.cs
+++ b/Oatmilk/It.Skip.cs
@@ -15,17 +15,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Action<T, TestInput> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be skipped for every element in the <paramref name="values"/> collection..
@@ -34,17 +34,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Func<T, TestInput, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be skipped for every element in the <paramref name="values"/> collection..
@@ -53,17 +53,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Action<T, TestInput> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be skipped for every element in the <paramref name="values"/> collection..
@@ -72,7 +72,7 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
 
@@ -80,42 +80,42 @@ public static partial class It
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Func<T, TestInput, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a test that will be skipped.
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The method body of the test where assertions should be put</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip(
     string description,
     Func<TestInput, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(description, timeout, lineNumber, filePath).When(body);
+  ) => Skip(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a test that will be skipped.
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The method body of the test where assertions should be put</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip(
     string description,
     Action<TestInput> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(description, timeout, lineNumber, filePath).When(body);
+  ) => Skip(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be skipped for every element in the <paramref name="values"/> collection..
@@ -124,17 +124,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be skipped for every element in the <paramref name="values"/> collection..
@@ -143,17 +143,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, descriptionFormatString, timeout, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionFormatString, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be skipped for every element in the <paramref name="values"/> collection..
@@ -162,17 +162,17 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Action<T> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a suite of tests that will be skipped for every element in the <paramref name="values"/> collection..
@@ -181,7 +181,7 @@ public static partial class It
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
   /// <param name="body">The method body of the test where assertions should be put. Each value from <paramref name="values"/> is passed to this.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
 
@@ -189,53 +189,53 @@ public static partial class It
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
     Func<T, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, descriptionResolver, timeout, lineNumber, filePath).When(body);
+  ) => Skip(values, descriptionResolver, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a test that will be skipped.
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The method body of the test where assertions should be put</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip(
     string description,
     Func<Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(description, timeout, lineNumber, filePath).When(body);
+  ) => Skip(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Creates a test that will be skipped.
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The method body of the test where assertions should be put</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Skip(
     string description,
     Action body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(description, timeout, lineNumber, filePath).When(body);
+  ) => Skip(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// A fluent api for creating a test that will be skipped. See <see cref="ItBlock.When(Action)"/>.
   /// </summary>
   /// <param name="description">The description of the test</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItBlock Skip(
     string description,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
@@ -243,7 +243,7 @@ public static partial class It
       Description: description,
       IsOnly: false,
       IsSkipped: true,
-      Timeout: timeout,
+      TestOptions: testOptions,
       LineNumber: lineNumber,
       FilePath: filePath
     );
@@ -254,16 +254,16 @@ public static partial class It
   /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionFormatString">A format string that is used to generate the test's description.  Each value from <paramref name="values"/> is used as the 0th param.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItEachBlock<T> Skip<T>(
     IEnumerable<T> values,
     string descriptionFormatString,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Skip(values, x => SafeFormat(descriptionFormatString, x), timeout, lineNumber, filePath);
+  ) => Skip(values, x => SafeFormat(descriptionFormatString, x), testOptions, lineNumber, filePath);
 
   /// <summary>
   /// A fluent api for creating a suite of tests that will be skipped. See <see cref="ItEachBlock{T}.When(Action{T})"/>.
@@ -271,15 +271,23 @@ public static partial class It
   /// <typeparam name="T">The type of the data to be passed to the test's method body</typeparam>
   /// <param name="values">A list of values to pass to the test</param>
   /// <param name="descriptionResolver">A function that is used to generate the test's description.  Each value from <paramref name="values"/> is passed to it.</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItEachBlock<T> Skip<T>(
     IEnumerable<T> values,
     Func<T, string> descriptionResolver,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   ) =>
-    new(values, descriptionResolver, IsOnly: false, IsSkipped: true, timeout, lineNumber, filePath);
+    new(
+      values,
+      descriptionResolver,
+      IsOnly: false,
+      IsSkipped: true,
+      testOptions,
+      lineNumber,
+      filePath
+    );
 }

--- a/Oatmilk/TestBuilder.Describe.cs
+++ b/Oatmilk/TestBuilder.Describe.cs
@@ -12,15 +12,18 @@ public static partial class TestBuilder
 
   /// <summary>
   /// Obsolete. Descriptions must be synchronous, and async bodies should be moved to <see cref="BeforeAll(Func{Task})"/>, <see cref="BeforeEach(Func{Task})" />.
-  /// Use <see cref="Describe(string,Action,TimeSpan?,int,string)"/> instead.
+  /// Use <see cref="Describe(string,Action,TestOptions,int,string)"/> instead.
   /// </summary>
   /// <param name="description"></param>
   /// <param name="body"></param>
-  /// <param name="timeout"></param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <exception cref="InvalidOperationException">This method will always throw an exception.</exception>
   [Obsolete(InvalidDescribeAsyncMethodCallMessage)]
-  public static void Describe(string description, Func<Task> body, TimeSpan? timeout = null) =>
-    throw new InvalidOperationException(InvalidDescribeAsyncMethodCallMessage);
+  public static void Describe(
+    string description,
+    Func<Task> body,
+    TestOptions testOptions = default
+  ) => throw new InvalidOperationException(InvalidDescribeAsyncMethodCallMessage);
 
   /// <summary>
   /// Describes a suite of tests.
@@ -28,28 +31,28 @@ public static partial class TestBuilder
   /// </summary>
   /// <param name="description">The description of this block of the test suite.</param>
   /// <param name="body">A callback which is immediately invoked to describe tests</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void Describe(
     string description,
     Action body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => Describe(description, timeout, lineNumber, filePath).As(body);
+  ) => Describe(description, testOptions, lineNumber, filePath).As(body);
 
   /// <summary>
   /// Describes a suite of tests using a fluent syntax.  Specify the body of the suite using the <see cref="DescribeBlock.As(Action)" /> method.
   /// </summary>
   /// <param name="description">The description of this block of the test suite.</param>
-  /// <param name="timeout">The timeout for each test in the test suite</param>
+  /// <param name="testOptions">The options for each test in the test suite, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <returns>A <see cref="DescribeBlock" /> object which allows for the creation of nested test suites.</returns>
   public static DescribeBlock Describe(
     string description,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
   )
@@ -58,7 +61,7 @@ public static partial class TestBuilder
       description,
       IsOnly: false,
       IsSkipped: false,
-      Timeout: timeout,
+      TestOptions: testOptions,
       lineNumber,
       filePath
     );
@@ -70,14 +73,14 @@ public static partial class TestBuilder
   /// <param name="Description">The description for the block of tests.</param>
   /// <param name="IsOnly">Should be the only test run in the suite</param>
   /// <param name="IsSkipped">Should be skipped</param>
-  /// <param name="Timeout">The timeout for each test in the test suite</param>
+  /// <param name="TestOptions">The options for each test in the test suite, including a timeout</param>
   /// <param name="LineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="FilePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public record DescribeBlock(
     string Description,
     bool IsOnly,
     bool IsSkipped,
-    TimeSpan? Timeout,
+    TestOptions TestOptions,
     int LineNumber,
     string FilePath
   )
@@ -96,7 +99,7 @@ public static partial class TestBuilder
         FilePath: FilePath,
         IsOnly: IsOnly,
         IsSkipped: IsSkipped,
-        Timeout: Timeout ?? CurrentScope?.Metadata.Timeout ?? DefaultTimeout
+        Timeout: TestOptions.Timeout ?? CurrentScope?.Metadata.Timeout ?? DefaultTimeout
       );
       if (RootScope == null)
       {
@@ -135,7 +138,7 @@ public static partial class TestBuilder
   /// <param name="Description">The description of the tests. This supports a format string taking</param>
   /// <param name="IsOnly">Should be the only test run in the suite</param>
   /// <param name="IsSkipped">Should be skipped</param>
-  /// <param name="Timeout">The timeout for the test</param>
+  /// <param name="TestOptions">The options for the tests, including a timeout</param>
   /// <param name="LineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="FilePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public record DescribeEachBlock<T>(
@@ -143,7 +146,7 @@ public static partial class TestBuilder
     Func<T, string> Description,
     bool IsOnly,
     bool IsSkipped,
-    TimeSpan? Timeout,
+    TestOptions TestOptions,
     int LineNumber,
     string FilePath
   )
@@ -165,7 +168,7 @@ public static partial class TestBuilder
           FilePath: FilePath,
           IsOnly: IsOnly,
           IsSkipped: IsSkipped,
-          Timeout: Timeout
+          TestOptions: TestOptions
         ).As(() => body(val));
       }
     }

--- a/Oatmilk/TestBuilder.It.cs
+++ b/Oatmilk/TestBuilder.It.cs
@@ -10,16 +10,16 @@ public static partial class TestBuilder
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The test body. Assertions should go in here</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void It(
     string description,
     Func<Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => It(description, timeout, lineNumber, filePath).When(body);
+  ) => It(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Adds a test to the current scope.
@@ -27,16 +27,16 @@ public static partial class TestBuilder
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The test body. Assertions should go in here</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void It(
     string description,
     Func<TestInput, Task> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => It(description, timeout, lineNumber, filePath).When(body);
+  ) => It(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Adds a test to the current scope.
@@ -44,16 +44,16 @@ public static partial class TestBuilder
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The test body. Assertions should go in here</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void It(
     string description,
     Action body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => It(description, timeout, lineNumber, filePath).When(body);
+  ) => It(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Adds a test to the current scope.
@@ -61,31 +61,31 @@ public static partial class TestBuilder
   /// </summary>
   /// <param name="description">The description of the test</param>
   /// <param name="body">The test body. Assertions should go in here</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static void It(
     string description,
     Action<TestInput> body,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => It(description, timeout, lineNumber, filePath).When(body);
+  ) => It(description, testOptions, lineNumber, filePath).When(body);
 
   /// <summary>
   /// Adds a test to the current scope.
   /// The body of the test will be run when the test is executed.
   /// </summary>
   /// <param name="description">The description of the test</param>
-  /// <param name="timeout">The timeout for the test</param>
+  /// <param name="testOptions">The options for the test, including the timeout</param>
   /// <param name="lineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="filePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public static ItBlock It(
     string description,
-    TimeSpan? timeout = null,
+    TestOptions testOptions = default,
     [CallerLineNumber] int lineNumber = 0,
     [CallerFilePath] string filePath = ""
-  ) => new(description, false, false, timeout, lineNumber, filePath);
+  ) => new(description, false, false, testOptions, lineNumber, filePath);
 
   /// <summary>
   /// Adds a test to the current scope, configured with a fluent API.
@@ -93,14 +93,14 @@ public static partial class TestBuilder
   /// <param name="Description">The description of the test</param>
   /// <param name="IsOnly">Should be the only test run in the suite</param>
   /// <param name="IsSkipped">Should be skipped</param>
-  /// <param name="Timeout">The timeout for the test</param>
+  /// <param name="TestOptions">The options for the test including a timeout</param>
   /// <param name="LineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="FilePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public record ItBlock(
     string Description,
     bool IsOnly,
     bool IsSkipped,
-    TimeSpan? Timeout,
+    TestOptions TestOptions,
     int LineNumber,
     string FilePath
   )
@@ -154,7 +154,7 @@ public static partial class TestBuilder
           FilePath: FilePath,
           IsOnly: IsOnly,
           IsSkipped: IsSkipped,
-          Timeout: Timeout ?? CurrentScopeNotNull.Metadata.Timeout
+          Timeout: TestOptions.Timeout ?? CurrentScopeNotNull.Metadata.Timeout
         )
       );
       CurrentScopeNotNull.TestBlocks.Add(tm);
@@ -168,7 +168,7 @@ public static partial class TestBuilder
   /// <param name="DescriptionResolver">A callback function to generate the description of the tests.  It is passed each value from <paramref name="Values"/></param>
   /// <param name="IsOnly">Should be the only test run in the suite</param>
   /// <param name="IsSkipped">Should be skipped</param>
-  /// <param name="Timeout">The timeout for the test</param>
+  /// <param name="TestOptions">The options for the test, including a timeout</param>
   /// <param name="LineNumber">Leave unset, used by the runtime to support running tests via the IDE</param>
   /// <param name="FilePath">Leave unset, used by the runtime to support running tests via the IDE</param>
   public record ItEachBlock<T>(
@@ -176,7 +176,7 @@ public static partial class TestBuilder
     Func<T, string> DescriptionResolver,
     bool IsOnly,
     bool IsSkipped,
-    TimeSpan? Timeout,
+    TestOptions TestOptions,
     int LineNumber,
     string FilePath
   )
@@ -242,7 +242,7 @@ public static partial class TestBuilder
             FilePath: FilePath,
             IsOnly: IsOnly,
             IsSkipped: IsSkipped,
-            Timeout: Timeout ?? CurrentScopeNotNull.Metadata.Timeout
+            Timeout: TestOptions.Timeout ?? CurrentScopeNotNull.Metadata.Timeout
           )
         );
         CurrentScopeNotNull.TestBlocks.Add(tm);

--- a/Oatmilk/TestOptions.cs
+++ b/Oatmilk/TestOptions.cs
@@ -1,0 +1,8 @@
+namespace Oatmilk;
+
+/// <summary>
+/// Options for running a test or suite of tests.  The most specific option from each level will be used.
+/// e.g. An It.Options will override a Describe.Options which will override the default TestOptions.
+/// </summary>
+/// <param name="Timeout">The timeout for the test or each test in the suite of tests. If unset, uses <see cref="TestBuilder.DefaultTimeout"/> </param>
+public record struct TestOptions(TimeSpan? Timeout);


### PR DESCRIPTION
This allows us to add options later down the line in a non breaking manner, and without having to amends heaps of different testbuilder methods