### PR TITLE
Add tests ensuring that lifecycle methods are executed in order

### DIFF
--- a/Oatmilk.Tests/Internal/TestRunner.cs
+++ b/Oatmilk.Tests/Internal/TestRunner.cs
@@ -1,0 +1,102 @@
+using System.ComponentModel;
+using FluentAssertions;
+using Oatmilk.Internal;
+
+namespace Oatmilk.Tests.Internal;
+
+public class TestRunnerTests
+{
+  [Describe("OatmilkTestRunner")]
+  public void TestRunnerTestsSpec()
+  {
+    TestScope rootScope = null!;
+    List<(TestScope TestScope, TestBlock TestBlock)> discoveredTests = null!;
+
+    void Setup(Action testMethod)
+    {
+      TestBuilder.Describe("A root node", testMethod);
+      rootScope = TestBuilder.ConsumeRootScope();
+      discoveredTests = OatmilkDiscoverer
+        .TraverseScopesAndYieldTestBlocks(rootScope, false)
+        .ToList();
+    }
+
+    Describe(
+      "For some tests with After and before methods",
+      () =>
+      {
+        List<string> lifetimeMethods = [];
+
+        BeforeAll(() =>
+        {
+          lifetimeMethods = [];
+          Setup(() =>
+          {
+            AfterAll(() => lifetimeMethods.Add("AfterAll"));
+            AfterEach((ctx) => lifetimeMethods.Add("AfterEach " + ctx.TestName));
+            BeforeAll(() => lifetimeMethods.Add("BeforeAll"));
+            BeforeEach(() => lifetimeMethods.Add("BeforeEach"));
+
+            It("should pass", () => lifetimeMethods.Add("should pass"));
+            It("should also pass", () => lifetimeMethods.Add("should also pass"));
+            It(
+              "should fail",
+              () =>
+              {
+                lifetimeMethods.Add("should fail");
+                true.Should().BeFalse();
+              }
+            );
+
+            Describe(
+              "A nested block",
+              () =>
+              {
+                It("nested should pass", () => lifetimeMethods.Add("nested should pass"));
+              }
+            );
+          });
+        });
+
+        It(
+          "should run the lifecycle methods in the correct order",
+          async () =>
+          {
+            var messageBus = new DummyMessageBus();
+            foreach (var test in discoveredTests)
+            {
+              var testRunner = new OatmilkTestBlockRunner(
+                test.TestScope,
+                test.TestBlock,
+                messageBus
+              );
+
+              var result = await testRunner.RunAsync(false);
+            }
+
+            lifetimeMethods
+              .Should()
+              .Equal(
+                [
+                  "BeforeAll",
+                  "BeforeEach",
+                  "should pass",
+                  "AfterEach should pass",
+                  "BeforeEach",
+                  "should also pass",
+                  "AfterEach should also pass",
+                  "BeforeEach",
+                  "should fail",
+                  "AfterEach should fail",
+                  "BeforeEach",
+                  "nested should pass",
+                  "AfterEach nested should pass",
+                  "AfterAll",
+                ]
+              );
+          }
+        );
+      }
+    );
+  }
+}

--- a/Oatmilk.Tests/TestVariants/ItTestVariants.cs
+++ b/Oatmilk.Tests/TestVariants/ItTestVariants.cs
@@ -162,12 +162,12 @@ public class ItTestVariants
               {
                 It(
                   "should fail because the timeout is too short",
-                  () => Task.Delay(TimeSpan.FromMilliseconds(100))
+                  () => Task.Delay(TimeSpan.FromMilliseconds(200))
                 );
 
                 It("should pass", () => Task.Delay(TimeSpan.FromMilliseconds(5)));
               },
-              new(Timeout: TimeSpan.FromMilliseconds(10))
+              new(Timeout: TimeSpan.FromMilliseconds(100))
             );
           });
         });

--- a/Oatmilk.Xunit/OatmilkXunitTestCase.cs
+++ b/Oatmilk.Xunit/OatmilkXunitTestCase.cs
@@ -75,8 +75,8 @@ internal partial class OatmilkXunitTestCase(
     CancellationTokenSource cancellationTokenSource
   )
   {
-    var oatmilkMessabeBus = new XunitOatmilkMessageBus(messageBus, this);
-    var result = await new OatmilkTestBlockRunner(TestScope, TestBlock, oatmilkMessabeBus).RunAsync(
+    var oatmilkMessageBus = new XunitOatmilkMessageBus(messageBus, this);
+    var result = await new OatmilkTestBlockRunner(TestScope, TestBlock, oatmilkMessageBus).RunAsync(
       SkippingDueToParentScopeOnly
     );
 

--- a/Oatmilk/FinishedTestContext.cs
+++ b/Oatmilk/FinishedTestContext.cs
@@ -6,7 +6,8 @@ namespace Oatmilk;
 /// </summary>
 /// <param name="Passed">True if the test passed.</param>
 /// <param name="TestOutput">The output of the test.</param>
-public record FinishedTestContext(bool Passed, TestOutput TestOutput);
+/// <param name="TestName">The name of the test.</param>
+public record FinishedTestContext(bool Passed, TestOutput TestOutput, string TestName);
 
 /// <summary>
 /// Represents the output of a test.

--- a/Oatmilk/Internal/OatmilkTestBlockRunner.cs
+++ b/Oatmilk/Internal/OatmilkTestBlockRunner.cs
@@ -71,6 +71,7 @@ internal class OatmilkTestBlockRunner(
     }
 
     messageBus.OnTestFinished(testBlock, testScope, result.Time, testOutputSink.GetOutput().Output);
+    testBlock.HasRun = true;
 
     messageBus.OnAfterTestSetupStarting(testBlock, testScope);
     await RunAfterEachesIncludingParentsAsync(finishedTestContext, testScope);
@@ -99,7 +100,7 @@ internal class OatmilkTestBlockRunner(
 
   private async Task RunAfterAllsIncludingParentsAsync(TestScope testScope)
   {
-    if (testScope.HasRunAfterAlls)
+    if (testScope.HasRunAfterAlls || !testScope.HasRunAllTests)
     {
       return;
     }

--- a/Oatmilk/Internal/OatmilkTestBlockRunner.cs
+++ b/Oatmilk/Internal/OatmilkTestBlockRunner.cs
@@ -37,7 +37,11 @@ internal class OatmilkTestBlockRunner(
     messageBus.OnBeforeTestSetupFinished(testBlock, testScope);
 
     messageBus.OnTestStarting(testBlock, testScope);
-    var finishedTestContext = new FinishedTestContext(true, testOutputSink.GetOutput());
+    var finishedTestContext = new FinishedTestContext(
+      true,
+      testOutputSink.GetOutput(),
+      testBlock.Metadata.Description
+    );
     try
     {
       tokenTimeout.CancelAfter(testBlock.Metadata.Timeout);

--- a/Oatmilk/Internal/TestDescription.cs
+++ b/Oatmilk/Internal/TestDescription.cs
@@ -13,6 +13,9 @@ internal record TestScope(TestScope? Parent, TestMetadata Metadata)
   internal List<TestBlock> TestBlocks { get; } = [];
   internal List<TestScope> Children { get; } = [];
 
+  internal bool HasRunAllTests =>
+    TestBlocks.All(x => x.HasRun) && Children.All(x => x.HasRunAllTests);
+
   internal string ScopeIndexPath =>
     Parent == null
       ? Metadata.ScopeIndex.ToString()
@@ -88,7 +91,9 @@ internal record TestMetadata(
 
 internal record TestBlock(Func<TestInput, Task> Body, TestMetadata Metadata)
 {
-  public bool ShouldSkipDueToIsSkippedOnThisOrParent(TestScope scope)
+  internal bool HasRun { get; set; }
+
+  internal bool ShouldSkipDueToIsSkippedOnThisOrParent(TestScope scope)
   {
     if (Metadata.IsSkipped)
     {
@@ -103,7 +108,7 @@ internal record TestBlock(Func<TestInput, Task> Body, TestMetadata Metadata)
     return false;
   }
 
-  public string GetDescription(TestScope scope)
+  internal string GetDescription(TestScope scope)
   {
     var sb = new StringBuilder();
     var parent = scope.Parent;


### PR DESCRIPTION
Just a suite of tests ensuring that the order of operations for tests are (with 2 tests):
BeforeAll
BeforeEach
Test
AfterEach
Test
AfterEach
AfterAll


Note:
These tests caught an issue with AfterAll where it would run after the first test, not the last.  The fix is okay if you are running all tests in the suite, but it will not currently run AfterAll if you are not running every test.