### PR TITLE
Allow targeting netstandard 2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-      <TargetFramework>net8.0</TargetFramework>
+      <TargetFrameworks>netstandard2;net8.0</TargetFrameworks>
       <ImplicitUsings>enable</ImplicitUsings>
       <Nullable>enable</Nullable>
       <Authors>Liam Morrow</Authors>
@@ -20,6 +20,7 @@
         Initial release
       </PackageReleaseNotes>
       <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+      <LangVersion>12</LangVersion>
 
     </PropertyGroup>
 

--- a/src/Oatmilk.Nunit/Oatmilk.Nunit.csproj
+++ b/src/Oatmilk.Nunit/Oatmilk.Nunit.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <PackageId>Oatmilk.Nunit</PackageId>
     <OutputType>Library</OutputType>
     <IsPackable>true</IsPackable>

--- a/src/Oatmilk/Oatmilk.csproj
+++ b/src/Oatmilk/Oatmilk.csproj
@@ -17,7 +17,19 @@
 
 
   <ItemGroup>
-    <Using Include="Oatmilk.Internal.Util"  Static="True"  />
+    <Using Include="Oatmilk.Internal.Util" Static="True" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="IsExternalInit" Version="1.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Nullable" Version="1.3.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/test/Oatmilk.Tests.Xunit/CommonTests/TestVariants/DescribeTestVariants.cs
+++ b/test/Oatmilk.Tests.Xunit/CommonTests/TestVariants/DescribeTestVariants.cs
@@ -282,7 +282,7 @@ public class DescribeTestVariants
                   () => Task.Delay(TimeSpan.FromMilliseconds(100))
                 );
 
-                It("should pass", () => Task.Delay(TimeSpan.FromMilliseconds(5)));
+                It("should pass", () => { });
               },
               new(Timeout: TimeSpan.FromMilliseconds(10))
             );


### PR DESCRIPTION
Except for Nunit, which only supports Net6.0 and not a netstandard version - target netstandard 2.0 as the lowest

We can still use the latest c# with backcompat codegen packages

Fixes #16 